### PR TITLE
Add standard functions for computing SCC

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ run(m)
 Here is an example of computing the social cost of carbon with MimiFUND:
 
 ```
+using Mimi
 using MimiFUND
 
 # Get the default version of the FUND model
@@ -84,13 +85,27 @@ scc = MimiFUND.compute_scc(m, emissionyear = 2020, prtp=0.025)
 There are several keyword arguments available to `compute_scc`. Note that the user must specify an `emissionyear`, but the rest have default values.
 ```
 compute_scc(m,
-    emissionyear = nothing,  # user must specify an emission year for the SCC calculation
+    year = nothing,  # user must specify an emission year for the SCC calculation
     gas = :C,  # which greenhouse gas to use. The default is :C from carbon dioxide. Other options are :CH4, :N2O, and :SF6.
-    yearstorun = 1050,  # the number of timesteps to run and use for the SCC calculation. Default is the full time dimension from 1950 to 3000
-    eta = 0.,  # eta parameter for ramsey discounting
-    prtp = 0.03,  # pure rate of time preference parameter for discounting
+    last_year = 3000,  # the last year to run and use for the SCC calculation. Default is the last year of the time dimension, 3000.
+    eta = 1.45,  # eta parameter for ramsey discounting representing the elasticity of marginal utility
+    prtp = 0.015,  # pure rate of time preference parameter for discounting
     useequityweights = false  # whether or not to use regional equity weighting
 )
+```
+
+There is an additional function for computing the SCC that also returns the MarginalModel that was used to compute it. It returns these two values as a NamedTuple of the form (scc=scc, mm=mm). The same keyword arguments from the `compute_scc` function are available for the `compute_scc_mm` function. Example:
+```
+using Mimi
+using MimiFUND
+
+result = compute_scc_mm(year=2020, last_year=2300, eta=0, prtp=0.03)
+
+result.scc  # returns the computed SCC value
+
+result.mm   # returns the Mimi MarginalModel
+
+result.mm[:climatedynamics, :temp]  # You can access the marginal results from the marginal model like this
 ```
 
 ## Versions and academic use policy

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ run(m)
 ```
 ## Calculating the Social Cost of Carbon
 
-Here is an example of computing the social cost of carbon with MimiFUND:
+Here is an example of computing the social cost of carbon with MimiFUND. Note that the units of the returned value are $/ton CO2.
 
 ```
 using Mimi
@@ -86,11 +86,11 @@ There are several keyword arguments available to `compute_scc`. Note that the us
 ```
 compute_scc(m = get_model(),  # if no model provided, will use the default MimiFUND model
     year = nothing,  # user must specify an emission year for the SCC calculation
-    gas = :C,  # which greenhouse gas to use. The default is :C from carbon dioxide. Other options are :CH4, :N2O, and :SF6.
+    gas = :CO2,  # which greenhouse gas to use. Other options are :CH4, :N2O, and :SF6.
     last_year = 3000,  # the last year to run and use for the SCC calculation. Default is the last year of the time dimension, 3000.
     eta = 1.45,  # eta parameter for ramsey discounting representing the elasticity of marginal utility
     prtp = 0.015,  # pure rate of time preference parameter for discounting
-    useequityweights = false  # whether or not to use regional equity weighting
+    equity_weights = false  # whether or not to use regional equity weighting
 )
 ```
 
@@ -105,7 +105,7 @@ result.scc  # returns the computed SCC value
 
 result.mm   # returns the Mimi MarginalModel
 
-result.mm[:climatedynamics, :temp]  # You can access the marginal results from the marginal model like this
+marginal_temp = result.mm[:climatedynamics, :temp]  # marginal results from the marginal model can be accessed like this
 ```
 
 ## Versions and academic use policy

--- a/README.md
+++ b/README.md
@@ -65,6 +65,33 @@ using MimiFUND
 m = MimiFUND.getmodel()
 run(m)
 ```
+## Calculating the Social Cost of Carbon
+
+Here is an example of computing the social cost of carbon with MimiFUND:
+
+```
+using MimiFUND
+
+# Get the default version of the FUND model
+m = MimiFUND.getmodel()
+
+# make any modifications to your model
+update_param!(m, ...)
+
+# Compute the SCC from your model
+scc = MimiFUND.computeSCC(m, emissionyear = 2020, prtp=0.025)
+```
+There are several keyword arguments available to `computeSCC`. Note that the user must specify an `emissionyear`, but the rest have default values.
+```
+computeSCC(m,
+    emissionyear = nothing,  # user must specify an emission year for the SCC calculation
+    gas = :C,  # which greenhouse gas to use. The default is :C from carbon dioxide. Other options are :CH4, :N2O, and :SF6.
+    yearstorun = 1050,  # the number of timesteps to run and use for the SCC calculation. Default is the full time dimension from 1950 to 3000
+    eta = 0.,  # eta parameter for ramsey discounting
+    prtp = 0.03,  # pure rate of time preference parameter for discounting
+    useequityweights = false  # whether or not to use regional equity weighting
+)
+```
 
 ## Versions and academic use policy
 

--- a/README.md
+++ b/README.md
@@ -73,18 +73,18 @@ Here is an example of computing the social cost of carbon with MimiFUND:
 using Mimi
 using MimiFUND
 
-# Get the default version of the FUND model
-m = MimiFUND.get_model()
+# Get the social cost of carbon in year 2020 from the default MimiFUND model:
+scc = MimiFUND.compute_scc(year = 2020)
 
-# make any modifications to your model
-update_param!(m, ...)
+# Or, you can also compute the SCC from a modified version of a MimiFUND model:
+m = MimiFUND.get_model() # Get the default version of the FUND model
+update_param!(m, :climatesensitivity, 5) # make any modifications to your model
+scc = MimiFUND.compute_scc(m, year = 2020) # Compute the SCC from your model
+```
 
-# Compute the SCC from your model
-scc = MimiFUND.compute_scc(m, emissionyear = 2020, prtp=0.025)
+There are several keyword arguments available to `compute_scc`. Note that the user must specify a `year` for the SCC calculation, but the rest of the keyword arguments have default values.
 ```
-There are several keyword arguments available to `compute_scc`. Note that the user must specify an `emissionyear`, but the rest have default values.
-```
-compute_scc(m,
+compute_scc(m = get_model(),  # if no model provided, will use the default MimiFUND model
     year = nothing,  # user must specify an emission year for the SCC calculation
     gas = :C,  # which greenhouse gas to use. The default is :C from carbon dioxide. Other options are :CH4, :N2O, and :SF6.
     last_year = 3000,  # the last year to run and use for the SCC calculation. Default is the last year of the time dimension, 3000.

--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ m = MimiFUND.get_model()
 update_param!(m, ...)
 
 # Compute the SCC from your model
-scc = MimiFUND.computeSCC(m, emissionyear = 2020, prtp=0.025)
+scc = MimiFUND.compute_scc(m, emissionyear = 2020, prtp=0.025)
 ```
-There are several keyword arguments available to `computeSCC`. Note that the user must specify an `emissionyear`, but the rest have default values.
+There are several keyword arguments available to `compute_scc`. Note that the user must specify an `emissionyear`, but the rest have default values.
 ```
-computeSCC(m,
+compute_scc(m,
     emissionyear = nothing,  # user must specify an emission year for the SCC calculation
     gas = :C,  # which greenhouse gas to use. The default is :C from carbon dioxide. Other options are :CH4, :N2O, and :SF6.
     yearstorun = 1050,  # the number of timesteps to run and use for the SCC calculation. Default is the full time dimension from 1950 to 3000

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The basic way of accessing a copy of the default MimiFUND model is the following
 ```
 using MimiFUND
 
-m = MimiFUND.getmodel()
+m = MimiFUND.get_model()
 run(m)
 ```
 ## Calculating the Social Cost of Carbon
@@ -73,7 +73,7 @@ Here is an example of computing the social cost of carbon with MimiFUND:
 using MimiFUND
 
 # Get the default version of the FUND model
-m = MimiFUND.getmodel()
+m = MimiFUND.get_model()
 
 # make any modifications to your model
 update_param!(m, ...)

--- a/examples/fund_demo.ipynb
+++ b/examples/fund_demo.ipynb
@@ -67,7 +67,7 @@
    },
    "outputs": [],
    "source": [
-    "m = MimiFUND.getmodel()\n",
+    "m = MimiFUND.get_model()\n",
     "run(m)"
    ]
   },

--- a/examples/main.jl
+++ b/examples/main.jl
@@ -1,7 +1,7 @@
 using Mimi
 using MimiFUND
 
-m = MimiFUND.getmodel()
+m = MimiFUND.get_model()
 run(m)
 
 explore(m)

--- a/src/MimiFUND.jl
+++ b/src/MimiFUND.jl
@@ -48,7 +48,7 @@ const global default_nsteps = 1050
 const global default_datadir = joinpath(dirname(@__FILE__), "..", "data")
 const global default_params = nothing
 
-function getmodel(; nsteps = default_nsteps, datadir = default_datadir, params = default_params)
+function get_model(; nsteps = default_nsteps, datadir = default_datadir, params = default_params)
 
     # ---------------------------------------------
     # Load parameters
@@ -252,6 +252,6 @@ function getmodel(; nsteps = default_nsteps, datadir = default_datadir, params =
 
 end
 
-getfund = getmodel
+getfund = get_model
 
 end #module

--- a/src/marginaldamage3.jl
+++ b/src/marginaldamage3.jl
@@ -4,10 +4,10 @@ Returns one default FUND model and one model with additional emissions of the sp
 function getmarginalmodels(; gas = :C, emissionyear = 2010, parameters = nothing, yearstorun = 1050)
 
     # Get default FUND model
-    m1 = MimiFUND.getmodel(nsteps = yearstorun, params = parameters)
+    m1 = MimiFUND.get_model(nsteps = yearstorun, params = parameters)
 
     # Get model to add marginal emissions to
-    m2 = MimiFUND.getmodel(nsteps = yearstorun, params = parameters)
+    m2 = MimiFUND.get_model(nsteps = yearstorun, params = parameters)
     add_comp!(m2, Mimi.adder, :marginalemission, before = :climateco2cycle, first = 1951)
     addem = zeros(yearstorun)
     addem[getindexfromyear(emissionyear)-1:getindexfromyear(emissionyear) + 8] .= 1.0

--- a/src/marginaldamages.jl
+++ b/src/marginaldamages.jl
@@ -7,10 +7,10 @@ function getmarginaldamages(; emissionyear=2010, parameters = nothing, yearstoag
     yearstorun = min(1050, getindexfromyear(emissionyear) + yearstoaggregate)
 
     # Get default FUND model
-    m1 = MimiFUND.getmodel(nsteps = yearstorun, params = parameters)
+    m1 = MimiFUND.get_model(nsteps = yearstorun, params = parameters)
 
     # Get model to add marginal emissions to
-    m2 = MimiFUND.getmodel(nsteps = yearstorun, params = parameters)
+    m2 = MimiFUND.get_model(nsteps = yearstorun, params = parameters)
     add_comp!(m2, Mimi.adder, :marginalemission, before = :climateco2cycle, first = 1951)
     addem = zeros(yearstorun)
     addem[getindexfromyear(emissionyear)-1:getindexfromyear(emissionyear) + 8] .= 1.0

--- a/src/montecarlo/run_fund_mcs.jl
+++ b/src/montecarlo/run_fund_mcs.jl
@@ -25,7 +25,7 @@ function run_fund_mcs(trials = 10000; ntimesteps = MimiFUND.default_nsteps + 1, 
     end
 
     # Run monte carlo trials
-    set_models!(mcs, getmodel())
+    set_models!(mcs, get_model())
     run_sim(mcs; trials = trials, ntimesteps = ntimesteps, output_dir = "$output_dir/results")
 
     return nothing

--- a/src/new_marginaldamages.jl
+++ b/src/new_marginaldamages.jl
@@ -1,6 +1,87 @@
 import Mimi.compinstance
 
 """
+computeSCC(m::Model=getmodel(); emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
+
+Computes the social cost of carbon (or other gas if specified) for an emissions pulse in `emissionyear`
+for the provided MimiFUND model. If no model is provided, the default model from MimiFUND.getmodel() is used.
+The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`.
+Optional regional equity weighting can be used by specifying `useequityweights=true`. 
+
+TODO: 
+- what should the default eta and prtp be?
+- This returns social cost of CO2 not carbon, should we multiply by 12/44 if gas==:C ?
+- `emissionyear` or `year` keyword
+- Should we keep the yearstorun keyword, or should we allow users to specify a `horizon` keyword representing the final year instead?
+"""
+function computeSCC(m::Model=getmodel(); emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
+
+    emissionyear === nothing ? error("Must specify an emissionyear. Try `computeSCC(m, emissionyear=2020)`.") : nothing
+
+    mm = getMarginalModel(m; emissionyear = emissionyear, gas = gas)
+
+    return computeSCC(mm, emissionyear=emissionyear, gas=gas, yearstorun=yearstorun, useequityweights=useequityweights, eta=eta, prtp=prtp)
+end
+
+"""
+computeSCC(mm::MarginalModel; emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
+
+Computes the social cost of carbon (or other gas if specified) for an emissions pulse in `emissionyear`
+for the provided MimiFUND MarginalModel. The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`.
+Optional regional equity weighting can be used by specifying useequityweights=true. 
+"""
+function computeSCC(mm::MarginalModel; emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
+
+    # Run the model
+    run(mm; ntimesteps = yearstorun + 1)
+    m1, m2 = mm.base, mm.marginal
+
+    damage1 = m1[:impactaggregation, :loss]
+    # Take out growth effect effect of run 2 by transforming the damage from run 2 into % of GDP of run 2, and then multiplying that with GDP of run 1
+    damage2 = m2[:impactaggregation, :loss] ./ m2[:socioeconomic, :income] .* m1[:socioeconomic, :income]
+
+    # Calculate the marginal damage between run 1 and 2 for each year/region
+    marginaldamage = (damage2 .- damage1) / 10000000.0  # The pulse was 1 MtCO2 for ten years, so divide by 10^7
+
+    ypc = m1[:socioeconomic, :ypc]
+
+    # Compute discount factor with or without equityweights
+    df = zeros(yearstorun + 1, 16)
+    if !useequityweights
+        for r = 1:16
+            x = 1.
+            for t = getindexfromyear(emissionyear):yearstorun
+                df[t, r] = x
+                gr = (ypc[t, r] - ypc[t - 1, r]) / ypc[t - 1,r]
+                x = x / (1. + prtp + eta * gr)
+            end
+        end
+    else
+        globalypc = m1[:socioeconomic, :globalypc]
+        df = Float64[t >= getindexfromyear(emissionyear) ? (globalypc[getindexfromyear(emissionyear)] / ypc[t, r]) ^ eta / (1.0 + prtp) ^ (t - getindexfromyear(emissionyear)) : 0.0 for t = 1:yearstorun + 1, r = 1:16]
+    end 
+
+    # Compute global SCC
+    scc = sum(marginaldamage[2:yearstorun, :] .* df[2:yearstorun, :]) #* (gas == :C ? 12./44. : 1) # convert to carbon from co2?
+    return scc
+end
+
+"""
+getMarginalModel(m::Model = getmodel(); emissionyear::Int = nothing, gas::Symbol = :C)
+
+Creates a Mimi MarginalModel where the provided m is the base model, and the marginal model has additional emissions of gas `gas` in year `emissionyear`.
+If no Model m is provided, the default model from MimiFUND.getmodel() is used as the base model.
+"""
+function getMarginalModel(m::Model = getmodel(); emissionyear::Int = nothing, gas::Symbol = :C)
+    emissionyear == nothing ? error("Must specify emissionyear. Try `getMarginalModels(m, emissionyear=2020)`.") : nothing 
+
+    mm = create_marginal_model(m)
+    add_marginal_emissions!(mm.marginal, emissionyear; gas = gas)
+
+    return mm
+end
+
+"""
 Creates a MarginalModel of FUND with additional emissions in the specified year for the specified gas. 
 """
 function create_marginal_FUND_model(; gas = :C, emissionyear = 2010, parameters = nothing, yearstorun = 1050)
@@ -12,7 +93,7 @@ function create_marginal_FUND_model(; gas = :C, emissionyear = 2010, parameters 
     mm = create_marginal_model(FUND)
     m1, m2 = mm.base, mm.marginal
 
-    add_marginal_emissions!(m2, emissionyear; gas = gas, yearstorun = yearstorun)
+    add_marginal_emissions!(m2, emissionyear; gas = gas)
 
     Mimi.build(m1)
     Mimi.build(m2)
@@ -22,11 +103,12 @@ end
 """
 Adds a marginalemission component to m, and sets the additional emissions if a year is specified.
 """
-function add_marginal_emissions!(m, emissionyear = nothing; gas = :C, yearstorun = 1050)
+function add_marginal_emissions!(m, emissionyear = nothing; gas = :C)
 
     # Add additional emissions to m
     add_comp!(m, Mimi.adder, :marginalemission, before = :climateco2cycle, first = 1951)
-    addem = zeros(yearstorun)
+    nyears = length(Mimi.time_labels(m))
+    addem = zeros(nyears - 1)   # starts one year later, in 1951
     if emissionyear != nothing 
         addem[getindexfromyear(emissionyear)-1:getindexfromyear(emissionyear) + 8] .= 1.0
     end
@@ -35,16 +117,16 @@ function add_marginal_emissions!(m, emissionyear = nothing; gas = :C, yearstorun
     # Reconnect the appropriate emissions in m
     if gas == :C
         connect_param!(m, :marginalemission, :input, :emissions, :mco2)
-        connect_param!(m, :climateco2cycle, :mco2, :marginalemission, :output, repeat([missing], yearstorun + 1))
+        connect_param!(m, :climateco2cycle, :mco2, :marginalemission, :output, repeat([missing], nyears))
     elseif gas == :CH4
         connect_param!(m, :marginalemission, :input, :emissions, :globch4)
-        connect_param!(m, :climatech4cycle, :globch4, :marginalemission, :output, repeat([missing], yearstorun + 1))
+        connect_param!(m, :climatech4cycle, :globch4, :marginalemission, :output, repeat([missing], nyears))
     elseif gas == :N2O
         connect_param!(m, :marginalemission, :input, :emissions, :globn2o)
-        connect_param!(m, :climaten2ocycle, :globn2o, :marginalemission, :output, repeat([missing], yearstorun + 1))
+        connect_param!(m, :climaten2ocycle, :globn2o, :marginalemission, :output, repeat([missing], nyears))
     elseif gas == :SF6
         connect_param!(m, :marginalemission, :input, :emissions,:globsf6)
-        connect_param!(m, :climatesf6cycle, :globsf6, :marginalemission, :output, repeat([missing], yearstorun + 1))
+        connect_param!(m, :climatesf6cycle, :globsf6, :marginalemission, :output, repeat([missing], nyears))
     else
         error("Unknown gas: $gas")
     end

--- a/src/new_marginaldamages.jl
+++ b/src/new_marginaldamages.jl
@@ -18,7 +18,7 @@ function compute_scc(m::Model=get_model(); emissionyear::Int = nothing, gas::Sym
 
     emissionyear === nothing ? error("Must specify an emissionyear. Try `compute_scc(m, emissionyear=2020)`.") : nothing
 
-    mm = getMarginalModel(m; emissionyear = emissionyear, gas = gas)
+    mm = get_marginal_model(m; emissionyear = emissionyear, gas = gas)
 
     return compute_scc(mm, emissionyear=emissionyear, gas=gas, yearstorun=yearstorun, useequityweights=useequityweights, eta=eta, prtp=prtp)
 end
@@ -67,13 +67,13 @@ function compute_scc(mm::MarginalModel; emissionyear::Int = nothing, gas::Symbol
 end
 
 """
-getMarginalModel(m::Model = get_model(); emissionyear::Int = nothing, gas::Symbol = :C)
+get_marginal_model(m::Model = get_model(); emissionyear::Int = nothing, gas::Symbol = :C)
 
 Creates a Mimi MarginalModel where the provided m is the base model, and the marginal model has additional emissions of gas `gas` in year `emissionyear`.
 If no Model m is provided, the default model from MimiFUND.get_model() is used as the base model.
 """
-function getMarginalModel(m::Model = get_model(); emissionyear::Int = nothing, gas::Symbol = :C)
-    emissionyear == nothing ? error("Must specify emissionyear. Try `getMarginalModels(m, emissionyear=2020)`.") : nothing 
+function get_marginal_model(m::Model = get_model(); emissionyear::Int = nothing, gas::Symbol = :C)
+    emissionyear == nothing ? error("Must specify emissionyear. Try `get_marginal_models(m, emissionyear=2020)`.") : nothing 
 
     mm = create_marginal_model(m)
     add_marginal_emissions!(mm.marginal, emissionyear; gas = gas)

--- a/src/new_marginaldamages.jl
+++ b/src/new_marginaldamages.jl
@@ -1,10 +1,10 @@
 import Mimi.compinstance
 
 """
-computeSCC(m::Model=getmodel(); emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
+computeSCC(m::Model=get_model(); emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
 
 Computes the social cost of carbon (or other gas if specified) for an emissions pulse in `emissionyear`
-for the provided MimiFUND model. If no model is provided, the default model from MimiFUND.getmodel() is used.
+for the provided MimiFUND model. If no model is provided, the default model from MimiFUND.get_model() is used.
 The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`.
 Optional regional equity weighting can be used by specifying `useequityweights=true`. 
 
@@ -14,7 +14,7 @@ TODO:
 - `emissionyear` or `year` keyword
 - Should we keep the yearstorun keyword, or should we allow users to specify a `horizon` keyword representing the final year instead?
 """
-function computeSCC(m::Model=getmodel(); emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
+function computeSCC(m::Model=get_model(); emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
 
     emissionyear === nothing ? error("Must specify an emissionyear. Try `computeSCC(m, emissionyear=2020)`.") : nothing
 
@@ -67,12 +67,12 @@ function computeSCC(mm::MarginalModel; emissionyear::Int = nothing, gas::Symbol 
 end
 
 """
-getMarginalModel(m::Model = getmodel(); emissionyear::Int = nothing, gas::Symbol = :C)
+getMarginalModel(m::Model = get_model(); emissionyear::Int = nothing, gas::Symbol = :C)
 
 Creates a Mimi MarginalModel where the provided m is the base model, and the marginal model has additional emissions of gas `gas` in year `emissionyear`.
-If no Model m is provided, the default model from MimiFUND.getmodel() is used as the base model.
+If no Model m is provided, the default model from MimiFUND.get_model() is used as the base model.
 """
-function getMarginalModel(m::Model = getmodel(); emissionyear::Int = nothing, gas::Symbol = :C)
+function getMarginalModel(m::Model = get_model(); emissionyear::Int = nothing, gas::Symbol = :C)
     emissionyear == nothing ? error("Must specify emissionyear. Try `getMarginalModels(m, emissionyear=2020)`.") : nothing 
 
     mm = create_marginal_model(m)
@@ -87,7 +87,7 @@ Creates a MarginalModel of FUND with additional emissions in the specified year 
 function create_marginal_FUND_model(; gas = :C, emissionyear = 2010, parameters = nothing, yearstorun = 1050)
 
     # Get default FUND model
-    FUND = getmodel(nsteps = yearstorun, params = parameters)
+    FUND = get_model(nsteps = yearstorun, params = parameters)
 
     # Build marginal model
     mm = create_marginal_model(FUND)

--- a/src/new_marginaldamages.jl
+++ b/src/new_marginaldamages.jl
@@ -1,7 +1,7 @@
 import Mimi.compinstance
 
 """
-computeSCC(m::Model=get_model(); emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
+compute_scc(m::Model=get_model(); emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
 
 Computes the social cost of carbon (or other gas if specified) for an emissions pulse in `emissionyear`
 for the provided MimiFUND model. If no model is provided, the default model from MimiFUND.get_model() is used.
@@ -14,23 +14,23 @@ TODO:
 - `emissionyear` or `year` keyword
 - Should we keep the yearstorun keyword, or should we allow users to specify a `horizon` keyword representing the final year instead?
 """
-function computeSCC(m::Model=get_model(); emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
+function compute_scc(m::Model=get_model(); emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
 
-    emissionyear === nothing ? error("Must specify an emissionyear. Try `computeSCC(m, emissionyear=2020)`.") : nothing
+    emissionyear === nothing ? error("Must specify an emissionyear. Try `compute_scc(m, emissionyear=2020)`.") : nothing
 
     mm = getMarginalModel(m; emissionyear = emissionyear, gas = gas)
 
-    return computeSCC(mm, emissionyear=emissionyear, gas=gas, yearstorun=yearstorun, useequityweights=useequityweights, eta=eta, prtp=prtp)
+    return compute_scc(mm, emissionyear=emissionyear, gas=gas, yearstorun=yearstorun, useequityweights=useequityweights, eta=eta, prtp=prtp)
 end
 
 """
-computeSCC(mm::MarginalModel; emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
+compute_scc(mm::MarginalModel; emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
 
 Computes the social cost of carbon (or other gas if specified) for an emissions pulse in `emissionyear`
 for the provided MimiFUND MarginalModel. The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`.
 Optional regional equity weighting can be used by specifying useequityweights=true. 
 """
-function computeSCC(mm::MarginalModel; emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
+function compute_scc(mm::MarginalModel; emissionyear::Int = nothing, gas::Symbol = :C, yearstorun::Int = 1050, useequityweights::Bool = false, eta::Float64 = 0., prtp::Float64 = 0.03)
 
     # Run the model
     run(mm; ntimesteps = yearstorun + 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,18 +83,18 @@ end #fund-integration testset
 # new_marginaldamages.jl
 
 # Test the default SCC function 
-scc = MimiFUND.computeSCC(emissionyear = 2020) 
+scc = MimiFUND.compute_scc(emissionyear = 2020) 
 @test scc isa Float64   # test that it's not missing or a NaN
 
 # Test with a modified model and more keyword arguments
 m = MimiFUND.get_model()
 update_param!(m, :climatesensitivity, 5)    
-scc = MimiFUND.computeSCC(m, emissionyear=2020, eta=0.85, prtp=0.0001, yearstorun=350, useequityweights=true)
+scc = MimiFUND.compute_scc(m, emissionyear=2020, eta=0.85, prtp=0.0001, yearstorun=350, useequityweights=true)
 @test scc isa Float64   # test that it's not missing or a NaN
 
 # Test getMarginalModel
 mm = MimiFUND.getMarginalModel(emissionyear=2020, gas=:CH4)
-scc = MimiFUND.computeSCC(mm; emissionyear=2020, gas=:CH4)
+scc = MimiFUND.compute_scc(mm; emissionyear=2020, gas=:CH4)
 @test scc isa Float64   # test that it's not missing or a NaN
 
 # Test old exported versions of the functions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,18 +13,18 @@ using CSVFiles
 @testset "fund-model" begin
 
 #default model exported by fund module
-global default_nsteps = 1050
-global m = MimiFUND.getmodel()
+default_nsteps = 1050
+m = MimiFUND.getmodel()
 run(m)
 @test Mimi.time_labels(m) == collect(1950:1:1950+default_nsteps)
 
 #default model created by MimiFUND.getmodel()
-global m1 = MimiFUND.getmodel()
+m1 = MimiFUND.getmodel()
 run(m1)
 @test Mimi.time_labels(m1) == collect(1950:1:1950+default_nsteps)
 
 #use optional args for MimiFUND.getmodel()
-global new_nsteps = 10
+new_nsteps = 10
 @test_throws ErrorException m2 = MimiFUND.getmodel(nsteps = new_nsteps) #should error because parameter lenghts won't match time dim
 
 end #fund-model testset
@@ -37,7 +37,7 @@ end #fund-model testset
 
 Mimi.reset_compdefs()
 
-global m = MimiFUND.getmodel()
+m = MimiFUND.getmodel()
 run(m)
 
 missingvalue = -999.999
@@ -81,6 +81,23 @@ end #fund-integration testset
 @testset "test-marginaldamages" begin
 
 # new_marginaldamages.jl
+
+# Test the default SCC function 
+scc = MimiFUND.computeSCC(emissionyear = 2020) 
+@test scc isa Float64   # test that it's not missing or a NaN
+
+# Test with a modified model and more keyword arguments
+m = MimiFUND.getmodel()
+update_param!(m, :climatesensitivity, 5)    
+scc = MimiFUND.computeSCC(m, emissionyear=2020, eta=0.85, prtp=0.0001, yearstorun=350, useequityweights=true)
+@test scc isa Float64   # test that it's not missing or a NaN
+
+# Test getMarginalModel
+mm = MimiFUND.getMarginalModel(emissionyear=2020, gas=:CH4)
+scc = MimiFUND.computeSCC(mm; emissionyear=2020, gas=:CH4)
+@test scc isa Float64   # test that it's not missing or a NaN
+
+# Test old exported versions of the functions
 scc = MimiFUND.get_social_cost()
 md = MimiFUND.getmarginaldamages()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,8 +92,8 @@ update_param!(m, :climatesensitivity, 5)
 scc = MimiFUND.compute_scc(m, emissionyear=2020, eta=0.85, prtp=0.0001, yearstorun=350, useequityweights=true)
 @test scc isa Float64   # test that it's not missing or a NaN
 
-# Test getMarginalModel
-mm = MimiFUND.getMarginalModel(emissionyear=2020, gas=:CH4)
+# Test get_marginal_model
+mm = MimiFUND.get_marginal_model(emissionyear=2020, gas=:CH4)
 scc = MimiFUND.compute_scc(mm; emissionyear=2020, gas=:CH4)
 @test scc isa Float64   # test that it's not missing or a NaN
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,9 +87,9 @@ scc1 = MimiFUND.compute_scc(year = 2020)
 @test scc1 isa Float64   # test that it's not missing or a NaN
 scc2 = MimiFUND.compute_scc(year = 2020, last_year=2300) 
 @test scc2 < scc1  # test that shorter horizon made it smaller
-scc3 = MimiFUND.compute_scc(year = 2020, last_year=2300, useequityweights=true) 
+scc3 = MimiFUND.compute_scc(year = 2020, last_year=2300, equity_weights=true) 
 @test scc3 > scc2  # test that equity weights made itbigger
-scc4 = MimiFUND.compute_scc(year = 2020, last_year=2300, useequityweights=true, eta=.8, prtp=0.01) 
+scc4 = MimiFUND.compute_scc(year = 2020, last_year=2300, equity_weights=true, eta=.8, prtp=0.01) 
 @test scc4 > scc3   # test that lower eta and prtp make scc higher
 scc5 = MimiFUND.compute_scc(year = 2020, gas=:CH4) 
 @test scc5 > scc1   # test social cost of methane is higher

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,18 +14,18 @@ using CSVFiles
 
 #default model exported by fund module
 default_nsteps = 1050
-m = MimiFUND.getmodel()
+m = MimiFUND.get_model()
 run(m)
 @test Mimi.time_labels(m) == collect(1950:1:1950+default_nsteps)
 
-#default model created by MimiFUND.getmodel()
-m1 = MimiFUND.getmodel()
+#default model created by MimiFUND.get_model()
+m1 = MimiFUND.get_model()
 run(m1)
 @test Mimi.time_labels(m1) == collect(1950:1:1950+default_nsteps)
 
-#use optional args for MimiFUND.getmodel()
+#use optional args for MimiFUND.get_model()
 new_nsteps = 10
-@test_throws ErrorException m2 = MimiFUND.getmodel(nsteps = new_nsteps) #should error because parameter lenghts won't match time dim
+@test_throws ErrorException m2 = MimiFUND.get_model(nsteps = new_nsteps) #should error because parameter lenghts won't match time dim
 
 end #fund-model testset
 
@@ -37,7 +37,7 @@ end #fund-model testset
 
 Mimi.reset_compdefs()
 
-m = MimiFUND.getmodel()
+m = MimiFUND.get_model()
 run(m)
 
 missingvalue = -999.999
@@ -87,7 +87,7 @@ scc = MimiFUND.computeSCC(emissionyear = 2020)
 @test scc isa Float64   # test that it's not missing or a NaN
 
 # Test with a modified model and more keyword arguments
-m = MimiFUND.getmodel()
+m = MimiFUND.get_model()
 update_param!(m, :climatesensitivity, 5)    
 scc = MimiFUND.computeSCC(m, emissionyear=2020, eta=0.85, prtp=0.0001, yearstorun=350, useequityweights=true)
 @test scc isa Float64   # test that it's not missing or a NaN


### PR DESCRIPTION
Questions:
- Is it okay that I've added the default value for the model argument to `computeSCC` to be `getmodel()`?
- Do we want the keyword argument to be `emissionyear` or `year` (I think this should be the same across models)
- What should the default values of `eta` and `prtp` be
- Do we want to keep the keyword argument `yearstorun=1050` which represents the number of timesteps to run and use for the SCC, or should we have a different keyword like `horizon=3000` that designates the final year to use. I personally prefer `horizon` and think it could be a standard keyword option implemented by all models, so that people can modify the horizon easily for the SCC calculation, without having to know the number of years to run.
- I've implemented `computeSCC(mm::MarginalModel; kwargs...)` in addition to `computeSCC(m::Model; kwargs)`. I'm uncertain if this is a good idea, because the user must re-specify the `emissionyear` and `gas` keywords they used to construct the marginalmodel when calling `computeSCC`. Consider the example:
```
m = MimiFUND.getmodel()
update_param!(m, :climatesensitivity, 5)
mm = MimiFUND.getMarginalModel(m, emissionyear=2020, gas=:CH4)

scc = computeSCC(mm, emissionyear=2020, gas=:CH4)    # user must specify emissionyear and gas again
```