### PR TITLE
Update to use new Simulation API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Mimi = "0.9"
 Distributions = "0.20"
 StatsBase = "0.30"
+CSVFiles = "0.16.0"
 
 [extras]
 CSVFiles = "5d742f6a-9f54-50ce-8119-2520741973ca"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,6 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Mimi = "0.9"
 Distributions = "0.20"
 StatsBase = "0.30"
-CSVFiles = "0.16.0"
 
 [extras]
 CSVFiles = "5d742f6a-9f54-50ce-8119-2520741973ca"

--- a/src/montecarlo/run_fund_mcs.jl
+++ b/src/montecarlo/run_fund_mcs.jl
@@ -10,10 +10,10 @@ Runs a Monte Carlo simulation with the FUND model over it's distributional param
 function run_fund_mcs(trials = 10000; ntimesteps = MimiFUND.default_nsteps + 1, output_dir = nothing, save_trials = false)
 
     # Set up output directories
-    output_dir = output_dir == nothing ? joinpath(@__DIR__, "../../output/", "SCC $(Dates.format(now(), "yyyy-mm-dd HH-MM-SS")) MC$trials") : output_dir
+    output_dir = output_dir === nothing ? joinpath(@__DIR__, "../../output/", "SCC $(Dates.format(now(), "yyyy-mm-dd HH-MM-SS")) MC$trials") : output_dir
     mkpath("$output_dir/results")
 
-    save_trials ? trials_output_filename = joinpath("$output_dir/trials.csv") : nothing
+    trials_output_filename = save_trials ?  joinpath("$output_dir/trials.csv") :  nothing
 
     # Get an instance of FUND's mcs
     mcs = getmcs()

--- a/src/montecarlo/run_fund_mcs.jl
+++ b/src/montecarlo/run_fund_mcs.jl
@@ -19,7 +19,7 @@ function run_fund_mcs(trials = 10000; ntimesteps = MimiFUND.default_nsteps + 1, 
     mcs = getmcs()
 
     # run monte carlo trials
-    run(mcs, get_model(), trials; trials_output_filename = trials_output_filename, ntimesteps = ntimesteps, results_output_dir = "$output_dir/results")
+    res = run(mcs, get_model(), trials; trials_output_filename = trials_output_filename, ntimesteps = ntimesteps, results_output_dir = "$output_dir/results")
 
-    return nothing
+    return res
 end

--- a/src/montecarlo/run_fund_mcs.jl
+++ b/src/montecarlo/run_fund_mcs.jl
@@ -13,20 +13,13 @@ function run_fund_mcs(trials = 10000; ntimesteps = MimiFUND.default_nsteps + 1, 
     output_dir = output_dir == nothing ? joinpath(@__DIR__, "../../output/", "SCC $(Dates.format(now(), "yyyy-mm-dd HH-MM-SS")) MC$trials") : output_dir
     mkpath("$output_dir/results")
 
+    save_trials ? trials_output_filename = joinpath("$output_dir/trials.csv") : nothing
+
     # Get an instance of FUND's mcs
     mcs = getmcs()
 
-    # Generate trials
-    if save_trials
-        filename = joinpath("$output_dir/trials.csv")
-        generate_trials!(mcs, trials; filename=filename)
-    else
-        generate_trials!(mcs, trials)
-    end
-
-    # Run monte carlo trials
-    set_models!(mcs, get_model())
-    run_sim(mcs; trials = trials, ntimesteps = ntimesteps, output_dir = "$output_dir/results")
+    # run monte carlo trials
+    run(mcs, get_model(), trials; trials_output_filename = trials_output_filename, ntimesteps = ntimesteps, results_output_dir = "$output_dir/results")
 
     return nothing
 end

--- a/src/montecarlo/run_fund_scc_mcs.jl
+++ b/src/montecarlo/run_fund_scc_mcs.jl
@@ -13,6 +13,7 @@ function run_fund_scc_mcs(trials = 10000; years = [2020], rates = [0.03], ntimes
     # Set up output directories
     output_dir = output_dir == nothing ? joinpath(@__DIR__, "../../output/", "SCC $(Dates.format(now(), "yyyy-mm-dd HH-MM-SS")) MC$trials") : output_dir
     mkpath("$output_dir/results")
+    save_trials ? trials_output_filename = joinpath(@__DIR__, "$output_dir/trials.csv") : trials_output_filename = nothing
 
     # Write header in SCC output file
     scc_file = joinpath(output_dir, "scc.csv")
@@ -26,22 +27,13 @@ function run_fund_scc_mcs(trials = 10000; years = [2020], rates = [0.03], ntimes
         :emissionyear   => years
     ]
 
+    # get models
     mcs = getmcs()
-
-    # Generate trials
-    if save_trials
-        filename = joinpath(@__DIR__, "$output_dir/trials.csv")
-        generate_trials!(mcs, trials; filename=filename)
-    else
-        generate_trials!(mcs, trials)
-    end
-
-    # Get FUND marginal model
     mm = create_marginal_FUND_model()
-    set_models!(mcs, mm)
-
+    models = [mcs, mm]
+    
     # Define scenario function
-    function _scenario_func(mcs::Simulation, tup::Tuple)
+    function _scenario_func(mcs::SimulationInstance, tup::Tuple)
         
         # Unpack scenario tuple argument
         (rate, emissionyear) = tup
@@ -55,7 +47,7 @@ function run_fund_scc_mcs(trials = 10000; years = [2020], rates = [0.03], ntimes
     end
 
     # Define post trial function
-    function scc_calculation(mcs::Simulation, trialnum::Int, ntimesteps::Int, tup::Tuple)
+    function scc_calculation(mcs::SimulationInstance, trialnum::Int, ntimesteps::Int, tup::Tuple)
 
         # Unpack scenario tuple argument
         (rate, emissionyear) = tup
@@ -82,10 +74,10 @@ function run_fund_scc_mcs(trials = 10000; years = [2020], rates = [0.03], ntimes
     end
 
     # Run monte carlo trials
-    run_sim(mcs;
-        models_to_run = 2, 
+    run(mcs, models, trials;
         ntimesteps = ntimesteps,
-        output_dir = "$output_dir/results",
+        trials_output_filename = trials_output_filename,
+        results_output_dir = "$output_dir/results",
         scenario_args = scenario_args, 
         scenario_func = _scenario_func,   
         post_trial_func = scc_calculation   

--- a/src/montecarlo/run_fund_scc_mcs.jl
+++ b/src/montecarlo/run_fund_scc_mcs.jl
@@ -11,7 +11,7 @@ the Social Cost of Carbon for the specified `years` and discount `rates`.
 function run_fund_scc_mcs(trials = 10000; years = [2020], rates = [0.03], ntimesteps = MimiFUND.default_nsteps + 1, output_dir = nothing, save_trials = false)
 
     # Set up output directories
-    output_dir = output_dir == nothing ? joinpath(@__DIR__, "../../output/", "SCC $(Dates.format(now(), "yyyy-mm-dd HH-MM-SS")) MC$trials") : output_dir
+    output_dir = output_dir === nothing ? joinpath(@__DIR__, "../../output/", "SCC $(Dates.format(now(), "yyyy-mm-dd HH-MM-SS")) MC$trials") : output_dir
     mkpath("$output_dir/results")
     save_trials ? trials_output_filename = joinpath(@__DIR__, "$output_dir/trials.csv") : trials_output_filename = nothing
 
@@ -27,10 +27,10 @@ function run_fund_scc_mcs(trials = 10000; years = [2020], rates = [0.03], ntimes
         :emissionyear   => years
     ]
 
-    # get models
+    # get models and sim
     mcs = getmcs()
     mm = create_marginal_FUND_model()
-    models = [mcs, mm]
+    models = [mm.base, mm.marginal] #fixing bug in Mimi so this can go back to models = mm
     
     # Define scenario function
     function _scenario_func(mcs::SimulationInstance, tup::Tuple)

--- a/src/montecarlo/run_fund_scc_mcs.jl
+++ b/src/montecarlo/run_fund_scc_mcs.jl
@@ -74,7 +74,7 @@ function run_fund_scc_mcs(trials = 10000; years = [2020], rates = [0.03], ntimes
     end
 
     # Run monte carlo trials
-    run(mcs, models, trials;
+    res = run(mcs, models, trials;
         ntimesteps = ntimesteps,
         trials_output_filename = trials_output_filename,
         results_output_dir = "$output_dir/results",
@@ -83,6 +83,6 @@ function run_fund_scc_mcs(trials = 10000; years = [2020], rates = [0.03], ntimes
         post_trial_func = scc_calculation   
         )
 
-    return nothing
+    return res
 end 
 


### PR DESCRIPTION
This PR updates all the `mcs` code to use the new Simulation API in Mimi v0.9.3.  @davidanthoff this is ready to be merged. 