### PR TITLE
pulse_size option and other changes to compute_scco2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 julia = "1"
-Mimi = "0.9.3"
+Mimi = "0.9.4"
 Distributions = "0.20, 0.21"
 StatsBase = "0.30, 0.31, 0.32"
 

--- a/Project.toml
+++ b/Project.toml
@@ -7,18 +7,19 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Mimi = "e4e893b0-ee5e-52ea-8111-44b3bdec128c"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
+[compat]
+Distributions = "0.20, 0.21"
+Mimi = "0.9"
+StatsBase = "0.30, 0.31, 0.32"
+julia = "1"
+
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 CSVFiles = "5d742f6a-9f54-50ce-8119-2520741973ca"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-
-[compat]
-julia = "1"
-Mimi = "0.9"
-Distributions = "0.20, 0.21"
-StatsBase = "0.30, 0.31, 0.32"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "DataFrames", "CSVFiles"]

--- a/README.md
+++ b/README.md
@@ -74,17 +74,17 @@ using Mimi
 using MimiFUND
 
 # Get the social cost of carbon in year 2020 from the default MimiFUND model:
-scc = MimiFUND.compute_scc(year = 2020)
+scc = MimiFUND.compute_scco2(year = 2020)
 
 # Or, you can also compute the SCC from a modified version of a MimiFUND model:
 m = MimiFUND.get_model() # Get the default version of the FUND model
 update_param!(m, :climatesensitivity, 5) # make any modifications to your model
-scc = MimiFUND.compute_scc(m, year = 2020) # Compute the SCC from your model
+scc = MimiFUND.compute_scco2(m, year = 2020) # Compute the SCC from your model
 ```
 
-There are several keyword arguments available to `compute_scc`. Note that the user must specify a `year` for the SCC calculation, but the rest of the keyword arguments have default values.
+There are several keyword arguments available to `compute_scco2`. Note that the user must specify a `year` for the SCC calculation, but the rest of the keyword arguments have default values.
 ```
-compute_scc(m = get_model(),  # if no model provided, will use the default MimiFUND model
+MimiFUND.compute_scco2(m = get_model(),  # if no model provided, will use the default MimiFUND model
     year = nothing,  # user must specify an emission year for the SCC calculation
     gas = :CO2,  # which greenhouse gas to use. Other options are :CH4, :N2O, and :SF6.
     last_year = 3000,  # the last year to run and use for the SCC calculation. Default is the last year of the time dimension, 3000.
@@ -94,18 +94,25 @@ compute_scc(m = get_model(),  # if no model provided, will use the default MimiF
 )
 ```
 
-There is an additional function for computing the SCC that also returns the MarginalModel that was used to compute it. It returns these two values as a NamedTuple of the form (scc=scc, mm=mm). The same keyword arguments from the `compute_scc` function are available for the `compute_scc_mm` function. Example:
+There is an additional function for computing the SCC that also returns the MarginalModel that was used to compute it. It returns these two values as a NamedTuple of the form (scc=scc, mm=mm). The same keyword arguments from the `compute_scco2` function are available for the `compute_sc_mm` function. Example:
 ```
 using Mimi
 using MimiFUND
 
-result = compute_scc_mm(year=2020, last_year=2300, eta=0, prtp=0.03)
+result = MimiFUND.compute_sc_mm(year = 2020, gas = :CO2, last_year = 2300, eta = 0, prtp = 0.03)
 
-result.scc  # returns the computed SCC value
+result.scc  # returns the computed SCCO2 value
 
 result.mm   # returns the Mimi MarginalModel
 
 marginal_temp = result.mm[:climatedynamics, :temp]  # marginal results from the marginal model can be accessed like this
+```
+
+There are separate functions available for calculating the social cost of other greenhouse gases. They are:
+```
+compute_scch4
+compute_scn2o
+compute_scsf6
 ```
 
 ## Versions and academic use policy

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pkg> add MimiFUND
 
 You probably also want to install the Mimi package into your julia environment, so that you can use some of the tools in there:
 
-```
+```julia
 pkg> add Mimi
 ```
 
@@ -59,7 +59,7 @@ pkg> up
 The model uses the Mimi framework and it is highly recommended to read the Mimi documentation first to understand the code structure. For starter code on running the model just once, see the code in the file `examples/main.jl`.
 
 The basic way of accessing a copy of the default MimiFUND model is the following:
-```
+```julia
 using MimiFUND
 
 m = MimiFUND.get_model()
@@ -69,24 +69,24 @@ run(m)
 
 Here is an example of computing the Social Cost of CO2 with MimiFUND. Note that the units of the returned value are 1995$ per metric tonne of CO2.
 
-```
+```julia
 using Mimi
 using MimiFUND
 
 # Get the Social Cost of CO2 in year 2020 from the default MimiFUND model:
 scc = MimiFUND.compute_scco2(year = 2020, eta = 0., prtp = 0.03, equity_weights = false)
 
-# Or, you can also compute the SCC from a modified version of a MimiFUND model:
-m = MimiFUND.get_model() # Get the default version of the FUND model
-update_param!(m, :climatesensitivity, 5) # make any modifications to your model
-scc = MimiFUND.compute_scco2(m, year = 2020) # Compute the SCC from your model
+# Or, you can also compute the SC-CO2 from a modified version of a MimiFUND model:
+m = MimiFUND.get_model()                        # Get the default version of the FUND model
+update_param!(m, :climatesensitivity, 5)        # make any modifications to your model using Mimi
+scc = MimiFUND.compute_scco2(m, year = 2020)    # Compute the SC-CO2 from your model
 ```
 There are also functions for computing the Social Cost of CH4, N2O, and SF6: `compute_scch4`, `compute_scn2o`, and `compute_scsf6`.
 These functions are all wrappers for the generic social cost function `compute_sc`, which takes a keyword `gas` with default value `:CO2`.
 
 There are several other keyword arguments available to `compute_sc`. Note that the user must specify a `year` for the SC calculation, 
 but the rest of the keyword arguments have default values.
-```
+```julia
 MimiFUND.compute_sc(m::Model=get_model();
         gas::Symbol = :CO2,                     
         year::Union{Int, Nothing} = nothing,    
@@ -101,25 +101,25 @@ MimiFUND.compute_sc(m::Model=get_model();
         seed::Union{Int, Nothing} = nothing)
 ```
 Description of keyword arguments:
-- `m`: a MimiFUND model from which to calculate the social cost. If no model is provided, the default MimiFUND model will be used. Note that the provided model `m` can be a highly modified MimiFUND model, but certain internal structures of the model need to remain in order for the `compute_sc` function to work. They are:
-    -- The original parameter connection between the `emissions` component and the climate cycling component for the specified `gas` must still be intact (this is where the pulse of emissions is added).
-    -- There must still be a `:socioeconomic` component with fields `:ypc` and `:globalypc` (used for discounting).
-    -- There must still be an `:impactaggregation` component with field `:loss`, which is the total damages value from with the social cost is calculated.
-- `gas`: which greenhouse gas to calculate the social cost for. The default is `:CO2`. Other options are `:CH4`, `:N2O`, and `:SF6`.
-- `year`: the user must specify an emission year for the SC calculation. Valid years are 1951 to 2990.
-- `eta`: the elasticity of marginal utility to be used in ramsey discounting. Setting `eta = 0` is equivalent to constant discounting with rate `prtp`.
-- `prtp`: pure rate of time preference parameter for discounting
-- `equity_weights`: whether or not to use regional equity weighting in discounting
-- `last_year`: the last year to run and use for the SC calculation. Default is the last year of FUND's time index, 3000.
-- `pulse_size`: the size of the marginal emissions pulse, in metric tonnes of the specified `gas`. Changing this value will not change the units of the returned value, which are always "1995$ per metric tonne of `gas`". The returned value is always normalized by the size of `pulse_size` that is used.
-- `return_mm`: whether or not to also return the MarginalModel used in the social cost calculation. If set to `true`, then a NamedTuple `(sc = sc, mm = mm)` of the social cost value and the MarginalModel used to compute it is returned.
-- `n`: By default, `n = nothing`, and a single value for the "best guess" social cost is returned. If a positive value for keyword `n` is specified, then a Monte Carlo simulation with sample size `n` will run, sampling from all of FUND's random variables, and a vector of `n` social cost values will be returned. Note that if the user has provided a modified model `m`, the user modifications may be overridden by the Monte Carlo simulation. If the user has modified certain parameter values, but they are parameters that have assigned random variable distributions in FUND, then they will be overwritten. For a list of which parameters have assigned random variable definitions, see "src/montecarlo/defmcs.jl"
-- `trials_output_filename`: an optional CSV file path to save all of the sampled trial data.
-- `seed`: the user can optionally provide a seed value, which will set the random seed before the simulation is run. This allows results to be replicated. 
+- *`m`*: a MimiFUND model from which to calculate the social cost. If no model is provided, the default MimiFUND model will be used. Note that the provided model `m` can be a highly modified MimiFUND model, but certain internal structures of the model need to remain in order for the `compute_sc` function to work. They are:
+    - The original parameter connection between the `emissions` component and the climate cycling component for the specified `gas` must still be intact (this is where the pulse of emissions is added).
+    - There must still be a `:socioeconomic` component with fields `:ypc` and `:globalypc` (used for discounting).
+    - There must still be an `:impactaggregation` component with field `:loss`, which is the total damages value from with the social cost is calculated.
+- *`gas`*: which greenhouse gas to calculate the social cost for. The default is `:CO2`. Other options are `:CH4`, `:N2O`, and `:SF6`.
+- *`year`*: the user must specify an emission year for the SC calculation. Valid years are 1951 to 2990.
+- *`eta`*: the elasticity of marginal utility to be used in ramsey discounting. Setting `eta = 0` is equivalent to constant discounting with rate `prtp`.
+- *`prtp`*: pure rate of time preference parameter for discounting
+- *`equity_weights`*: whether or not to use regional equity weighting in discounting
+- *`last_year`*: the last year to run and use for the SC calculation. Default is the last year of FUND's time index, 3000.
+- *`pulse_size`*: the size of the marginal emissions pulse, in metric tonnes of the specified `gas`. Changing this value will not change the units of the returned value, which are always "1995$ per metric tonne of `gas`". The returned value is always normalized by the size of `pulse_size` that is used.
+- *`return_mm`*: whether or not to also return the MarginalModel used in the social cost calculation. If set to `true`, then a NamedTuple `(sc = sc, mm = mm)` of the social cost value and the MarginalModel used to compute it is returned.
+- *`n`*: By default, `n = nothing`, and a single value for the "best guess" social cost is returned. If a positive value for keyword `n` is specified, then a Monte Carlo simulation with sample size `n` will run, sampling from all of FUND's random variables, and a vector of `n` social cost values will be returned. Note that if the user has provided a modified model `m`, the user modifications may be overwritten by the Monte Carlo simulation. If the user has modified certain parameter values, but they are parameters that have assigned random variable distributions in FUND, then they will be overwritten by the sampled values. For a list of which parameters have assigned random variable definitions, see "src/montecarlo/defmcs.jl"
+- *`trials_output_filename`*: an optional CSV file path to save all of the sampled trial data.
+- *`seed`*: the user can optionally provide a seed value, which will set the random seed before the simulation is run. This allows results to be replicated. 
 
 
 Example Monte Carlo simulation:
-```
+```julia
 using Mimi
 using MimiFUND
 
@@ -133,7 +133,7 @@ values_hi_discounting = MimiFUND.compute_sc(year = 2020, gas = :CO2, eta = 1., p
 ```
 
 Example of working with the MarginalModel from setting `return_mm = true`:
-```
+```julia
 using Mimi
 using MimiFUND
 

--- a/README.md
+++ b/README.md
@@ -101,21 +101,21 @@ MimiFUND.compute_sc(m::Model=get_model();
         seed::Union{Int, Nothing} = nothing)
 ```
 Description of keyword arguments:
-- *`m`*: a MimiFUND model from which to calculate the social cost. If no model is provided, the default MimiFUND model will be used. Note that the provided model `m` can be a highly modified MimiFUND model, but certain internal structures of the model need to remain in order for the `compute_sc` function to work. They are:
+- **`m`**: a MimiFUND model from which to calculate the social cost. If no model is provided, the default MimiFUND model will be used. Note that the provided model `m` can be a highly modified MimiFUND model, but certain internal structures of the model need to remain in order for the `compute_sc` function to work. They are:
     - The original parameter connection between the `emissions` component and the climate cycling component for the specified `gas` must still be intact (this is where the pulse of emissions is added).
     - There must still be a `:socioeconomic` component with fields `:ypc` and `:globalypc` (used for discounting).
-    - There must still be an `:impactaggregation` component with field `:loss`, which is the total damages value from with the social cost is calculated.
-- *`gas`*: which greenhouse gas to calculate the social cost for. The default is `:CO2`. Other options are `:CH4`, `:N2O`, and `:SF6`.
-- *`year`*: the user must specify an emission year for the SC calculation. Valid years are 1951 to 2990.
-- *`eta`*: the elasticity of marginal utility to be used in ramsey discounting. Setting `eta = 0` is equivalent to constant discounting with rate `prtp`.
-- *`prtp`*: pure rate of time preference parameter for discounting
-- *`equity_weights`*: whether or not to use regional equity weighting in discounting
-- *`last_year`*: the last year to run and use for the SC calculation. Default is the last year of FUND's time index, 3000.
-- *`pulse_size`*: the size of the marginal emissions pulse, in metric tonnes of the specified `gas`. Changing this value will not change the units of the returned value, which are always "1995$ per metric tonne of `gas`". The returned value is always normalized by the size of `pulse_size` that is used.
-- *`return_mm`*: whether or not to also return the MarginalModel used in the social cost calculation. If set to `true`, then a NamedTuple `(sc = sc, mm = mm)` of the social cost value and the MarginalModel used to compute it is returned.
-- *`n`*: By default, `n = nothing`, and a single value for the "best guess" social cost is returned. If a positive value for keyword `n` is specified, then a Monte Carlo simulation with sample size `n` will run, sampling from all of FUND's random variables, and a vector of `n` social cost values will be returned. Note that if the user has provided a modified model `m`, the user modifications may be overwritten by the Monte Carlo simulation. If the user has modified certain parameter values, but they are parameters that have assigned random variable distributions in FUND, then they will be overwritten by the sampled values. For a list of which parameters have assigned random variable definitions, see "src/montecarlo/defmcs.jl"
-- *`trials_output_filename`*: an optional CSV file path to save all of the sampled trial data.
-- *`seed`*: the user can optionally provide a seed value, which will set the random seed before the simulation is run. This allows results to be replicated. 
+    - There must still be an `:impactaggregation` component with field `:loss`, which is the total damages value from which the social cost is calculated.
+- **`gas`**: which greenhouse gas to calculate the social cost for. The default is `:CO2`. Other options are `:CH4`, `:N2O`, and `:SF6`.
+- **`year`**: the user must specify an emission year for the SC calculation. Valid years are 1951 to 2990.
+- **`eta`**: the elasticity of marginal utility to be used in ramsey discounting. Setting `eta = 0` is equivalent to constant discounting with rate `prtp`.
+- **`prtp`**: pure rate of time preference parameter for discounting
+- **`equity_weights`**: whether or not to use regional equity weighting in discounting
+- **`last_year`**: the last year to run and use for the SC calculation. Default is the last year of FUND's time index, 3000.
+- **`pulse_size`**: the size of the marginal emissions pulse, in metric tonnes of the specified `gas`. Changing this value will not change the units of the returned value, which are always "1995$ per metric tonne of `gas`". The returned value is always normalized by the size of `pulse_size` that is used.
+- **`return_mm`**: whether or not to also return the MarginalModel used in the social cost calculation. If set to `true`, then a NamedTuple `(sc = sc, mm = mm)` of the social cost value and the MarginalModel used to compute it is returned.
+- **`n`**: By default, `n = nothing`, and a single value for the "best guess" social cost is returned. If a positive value for keyword `n` is specified, then a Monte Carlo simulation with sample size `n` will run, sampling from all of FUND's random variables, and a vector of `n` social cost values will be returned. Note that if the user has provided a modified model `m`, the user modifications may be overwritten by the Monte Carlo simulation. If the user has modified certain parameter values, but they are parameters that have assigned random variable distributions in FUND, then they will be overwritten by the sampled values. For a list of which parameters have assigned random variable definitions, see "src/montecarlo/defmcs.jl"
+- **`trials_output_filename`**: an optional CSV file path to save all of the sampled trial data.
+- **`seed`**: the user can optionally provide a seed value, which will set the random seed before the simulation is run. This allows results to be replicated. 
 
 
 Example Monte Carlo simulation:

--- a/src/MimiFUND.jl
+++ b/src/MimiFUND.jl
@@ -1,7 +1,8 @@
 module MimiFUND
 
 using Mimi
-using DelimitedFiles #base.DelimitedFiles
+using DelimitedFiles
+using Random
 
 include("helper.jl")
 

--- a/src/montecarlo/run_fund_scc_mcs.jl
+++ b/src/montecarlo/run_fund_scc_mcs.jl
@@ -37,7 +37,7 @@ function run_fund_scc_mcs(trials = 10000; years = [2020], rates = [0.03], ntimes
     end
 
     # Get FUND marginal model
-    mm = create_marginal_FUND_model()
+    mm = get_marginal_model()
     set_models!(mcs, mm)
 
     # Define scenario function

--- a/src/montecarlo/run_fund_scc_mcs.jl
+++ b/src/montecarlo/run_fund_scc_mcs.jl
@@ -30,7 +30,6 @@ function run_fund_scc_mcs(trials = 10000; years = [2020], rates = [0.03], ntimes
     # get models and sim
     mcs = getmcs()
     mm = get_marginal_model()
-    models = [mm.base, mm.marginal] #fixing bug in Mimi so this can go back to models = mm
     
     # Define scenario function
     function _scenario_func(mcs::SimulationInstance, tup::Tuple)
@@ -39,10 +38,10 @@ function run_fund_scc_mcs(trials = 10000; years = [2020], rates = [0.03], ntimes
         (rate, emissionyear) = tup
     
         # Get models
-        base, marginal = mcs.models
+        mm = mcs.models[1]
     
         # Perturb emissons in the marginal model
-        perturb_marginal_emissions!(marginal, emissionyear)
+        perturb_marginal_emissions!(mm.marginal, emissionyear)
     
     end
 
@@ -53,11 +52,11 @@ function run_fund_scc_mcs(trials = 10000; years = [2020], rates = [0.03], ntimes
         (rate, emissionyear) = tup
     
         # Get marginal damages
-        base, marginal = mcs.models
-        marginaldamages = (marginal[:impactaggregation, :loss] - base[:impactaggregation, :loss]) / 10000000.0
+        mm = mcs.models[1]
+        marginaldamages = mm[:impactaggregation, :loss]
     
         # Calculate discount factor
-        T = ntimesteps == typemax(Int) ? length(Mimi.dimension(base, :time)) : ntimesteps
+        T = ntimesteps == typemax(Int) ? length(Mimi.dimension(mm.base, :time)) : ntimesteps
         discount_factor = zeros(T)
         idx = getindexfromyear(emissionyear)
         discount_factor[idx:T] = [1 / ((1 + rate) ^ t) for t in 0:T-idx]
@@ -74,7 +73,7 @@ function run_fund_scc_mcs(trials = 10000; years = [2020], rates = [0.03], ntimes
     end
 
     # Run monte carlo trials
-    res = run(mcs, models, trials;
+    res = run(mcs, mm, trials;
         ntimesteps = ntimesteps,
         trials_output_filename = trials_output_filename,
         results_output_dir = "$output_dir/results",

--- a/src/new_marginaldamages.jl
+++ b/src/new_marginaldamages.jl
@@ -1,5 +1,10 @@
 import Mimi.compinstance
 
+"""
+compute_scc(m::Model=get_model(); year::Int = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+
+Debrecated function for calculating the social cost of carbon for a MimiFUND model. Use `compute_scco2`, `compute_scch4`, `compute_scn2o`, or `compute_scsf6` instead.
+"""
 function compute_scc(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
     @warn("Deprecation warning: `compute_scc` is deprecated. Use `compute_scco2` or other gas-specific functions instead.")
     year === nothing ? error("Must specify an emission year. Try `compute_scc(year=2020)`.") : nothing

--- a/src/new_marginaldamages.jl
+++ b/src/new_marginaldamages.jl
@@ -1,36 +1,93 @@
 import Mimi.compinstance
 
-"""
-compute_scc(m::Model=get_model(); year::Int = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
-
-Computes the social cost of CO2 (or other gas if specified) for an emissions pulse in `year`
-for the provided MimiFUND model. If no model is provided, the default model from MimiFUND.get_model() is used.
-The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`.
-Optional regional equity weighting can be used by specifying `equity_weights=true`. 
-`pulse_size` controls the size of the marginal emission pulse.
-"""
 function compute_scc(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
-
-    year === nothing ? error("Must specify an emission year. Try `compute_scc(m, year=2020)`.") : nothing
-    !(last_year in 1950:3000) ? error("Invlaid value of $last_year for last_year. last_year must be within the model's time index 1950:3000.") : nothing
-    !(year in 1950:last_year) ? error("Cannot compute the scc for year $year, year must be within the model's time index 1950:$last_year.") : nothing
-
-    mm = get_marginal_model(m; year = year, gas = gas, pulse_size = pulse_size)
-
-    return _compute_scc(mm, year=year, gas=gas, last_year=last_year, equity_weights=equity_weights, eta=eta, prtp=prtp)
+    @warn("Deprecation warning: `compute_scc` is deprecated. Use `compute_scco2` or other gas-specific functions instead.")
+    year === nothing ? error("Must specify an emission year. Try `compute_scc(year=2020)`.") : nothing
+    return compute_social_cost(m, year = year, gas = gas, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
 end
 
 """
-compute_scc_mm(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+compute_scco2(m::Model=get_model(); year::Int = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+
+Computes the social cost of CO2 for the specified `year` for the provided MimiFUND model `m`. 
+If no model is provided, the default model from MimiFUND.get_model() is used.
+The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`, with defaults of 1.45 and 0.015.
+Units of the returned value are [\$ per tonne CO2] in 1995USD.
+Optional regional equity weighting can be used by specifying `equity_weights = true`. 
+The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric tonnes of CO2.
+"""
+function compute_scco2(m::Model=get_model(); year::Union{Int, Nothing} = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+    year === nothing ? error("Must specify an emission year. Try `compute_scco2(year=2020)`.") : nothing
+    return compute_social_cost(m, year = year, gas = :CO2, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
+end
+
+"""
+compute_scch4(m::Model=get_model(); year::Int = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+
+Computes the social cost of CH4 for the specified `year` for the provided MimiFUND model `m`. 
+If no model is provided, the default model from MimiFUND.get_model() is used.
+The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`, with defaults of 1.45 and 0.015.
+Units of the returned value are [\$ per tonne CH4] in 1995USD.
+Optional regional equity weighting can be used by specifying `equity_weights = true`. 
+The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric tonnes of CH4.
+"""
+function compute_scch4(m::Model=get_model(); year::Union{Int, Nothing} = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+    year === nothing ? error("Must specify an emission year with keyword argument `year`. Try `compute_scch4(year=2020)`.") : nothing
+    return compute_social_cost(m, year = year, gas = :CH4, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
+end
+
+"""
+compute_scn2o(m::Model=get_model(); year::Int = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+
+Computes the social cost of N2O for the specified `year` for the provided MimiFUND model `m`. 
+If no model is provided, the default model from MimiFUND.get_model() is used.
+The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`, with defaults of 1.45 and 0.015.
+Units of the returned value are [\$ per tonne N2O] in 1995USD.
+Optional regional equity weighting can be used by specifying `equity_weights = true`. 
+The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric tonnes of N2O.
+"""
+function compute_scn2o(m::Model=get_model(); year::Union{Int, Nothing} = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+    year === nothing ? error("Must specify an emission year with keyword argument `year`. Try `compute_scn2o(year=2020)`.") : nothing
+    return compute_social_cost(m, year = year, gas = :N2O, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
+end
+
+"""
+compute_scsf6(m::Model=get_model(); year::Int = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+
+Computes the social cost of SF6 for the specified `year` for the provided MimiFUND model `m`. 
+If no model is provided, the default model from MimiFUND.get_model() is used.
+The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`, with defaults of 1.45 and 0.015.
+Units of the returned value are [\$ per tonne SF6] in 1995USD.
+Optional regional equity weighting can be used by specifying `equity_weights = true`. 
+The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric tonnes of SF6.
+"""
+function compute_scsf6(m::Model=get_model(); year::Union{Int, Nothing} = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+    year === nothing ? error("Must specify an emission year with keyword argument `year`. Try `compute_scn2o(year=2020)`.") : nothing
+    return compute_social_cost(m, year = year, gas = :SF6, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
+end
+
+# helper function called by each gas-specific function for computing the social cost
+function compute_social_cost(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+    year === nothing ? error("Must specify an emission year. Try `compute_social_cost(year=2020)`.") : nothing
+    !(last_year in 1950:3000) ? error("Invlaid value for `last_year`: $last_year. `last_year` must be within the model's time index 1950:3000.") : nothing
+    !(year in 1950:last_year) ? error("Invalid value for `year`: $year. `year` must be within the model's time index 1950:$last_year.") : nothing
+
+    mm = get_marginal_model(m; year = year, gas = gas, pulse_size = pulse_size)
+
+    return _compute_scc(mm, year = year, gas = gas, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
+end
+
+"""
+compute_sc_mm(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
 
 Returns a NamedTuple (scc=scc, mm=mm) of the social cost of carbon and the MarginalModel used to compute it.
 Computes the social cost of CO2 (or other gas if specified) for an emissions pulse in `year`
 for the provided MimiFUND model. If no model is provided, the default model from MimiFUND.get_model() is used.
 The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`.
 Optional regional equity weighting can be used by specifying `equity_weights=true`. 
-`pulse_size` controls the size of the marginal emission pulse.
+The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric tonnes.
 """
-function compute_scc_mm(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+function compute_sc_mm(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
     year === nothing ? error("Must specify an emission year. Try `compute_scc_mm(m, year=2020)`.") : nothing
     !(last_year in 1950:3000) ? error("Invlaid value of $last_year for last_year. last_year must be within the model's time index 1950:3000.") : nothing
     !(year in 1950:last_year) ? error("Cannot compute the scc for year $year, year must be within the model's time index 1950:$last_year.") : nothing
@@ -76,12 +133,12 @@ end
 get_marginal_model(m::Model = get_model(); year::Int = nothing, gas::Symbol = :CO2, pulse_size::Float64 = 1e7)
 
 Creates a Mimi MarginalModel where the provided m is the base model, and the marginal model has additional emissions of gas `gas` in year `year`.
+If no year is provided, the marginal emissions component will be added without an additional pulse.
 If no Model m is provided, the default model from MimiFUND.get_model() is used as the base model.
-`pulse_size` controls the size of the marginal emission pulse.
+The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric tonnes.
 """
-function get_marginal_model(m::Model = get_model(); year::Int = nothing, gas::Symbol = :CO2, pulse_size::Float64 = 1e7)
-    year === nothing ? error("Must specify emission year. Try `get_marginal_model(m, year=2020)`.") : nothing 
-    !(year in 1950:3000) ? error("Cannot add marginal emissions in $year, year must be within the model's time index 1950:3000.") : nothing
+function get_marginal_model(m::Model = get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, pulse_size::Float64 = 1e7)
+    year !== nothing && !(year in 1950:3000) ? error("Cannot add marginal emissions in $year, year must be within the model's time index 1950:3000.") : nothing
 
     mm = create_marginal_model(m, pulse_size)
     add_marginal_emissions!(mm.marginal, year; gas = gas, pulse_size = pulse_size)
@@ -91,9 +148,9 @@ end
 
 """
 Adds a marginalemission component to `m`, and sets the additional emissions if a year is specified.
-`pulse_size` controls the size of the marginal emission pulse.
+The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric tonnes.
 """
-function add_marginal_emissions!(m, year = nothing; gas = :CO2, pulse_size::Float64 = 1e7)
+function add_marginal_emissions!(m, year::Union{Int, Nothing} = nothing; gas::Symbol = :CO2, pulse_size::Float64 = 1e7)
 
     # Add additional emissions to m
     add_comp!(m, Mimi.adder, :marginalemission, before = :climateco2cycle, first = 1951)
@@ -141,7 +198,7 @@ end
 
 
 """
-Returns a matrix of marginal damages per one ton of additional emissions of the specified gas in the specified year.
+Returns a matrix of marginal damages per one metric tonne of additional emissions of the specified gas in the specified year.
 """
 function getmarginaldamages(; year=2010, parameters = nothing, gas = :CO2, pulse_size::Float64 = 1e7) 
 

--- a/src/new_marginaldamages.jl
+++ b/src/new_marginaldamages.jl
@@ -1,39 +1,41 @@
 import Mimi.compinstance
 
 """
-compute_scc(m::Model=get_model(); year::Int = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015)
+compute_scc(m::Model=get_model(); year::Int = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
 
 Computes the social cost of CO2 (or other gas if specified) for an emissions pulse in `year`
 for the provided MimiFUND model. If no model is provided, the default model from MimiFUND.get_model() is used.
 The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`.
 Optional regional equity weighting can be used by specifying `equity_weights=true`. 
+`pulse_size` controls the size of the marginal emission pulse.
 """
-function compute_scc(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015)
+function compute_scc(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
 
     year === nothing ? error("Must specify an emission year. Try `compute_scc(m, year=2020)`.") : nothing
     !(last_year in 1950:3000) ? error("Invlaid value of $last_year for last_year. last_year must be within the model's time index 1950:3000.") : nothing
     !(year in 1950:last_year) ? error("Cannot compute the scc for year $year, year must be within the model's time index 1950:$last_year.") : nothing
 
-    mm = get_marginal_model(m; year = year, gas = gas)
+    mm = get_marginal_model(m; year = year, gas = gas, pulse_size = pulse_size)
 
     return _compute_scc(mm, year=year, gas=gas, last_year=last_year, equity_weights=equity_weights, eta=eta, prtp=prtp)
 end
 
 """
-compute_scc_mm(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015)
+compute_scc_mm(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
 
 Returns a NamedTuple (scc=scc, mm=mm) of the social cost of carbon and the MarginalModel used to compute it.
 Computes the social cost of CO2 (or other gas if specified) for an emissions pulse in `year`
 for the provided MimiFUND model. If no model is provided, the default model from MimiFUND.get_model() is used.
 The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`.
 Optional regional equity weighting can be used by specifying `equity_weights=true`. 
+`pulse_size` controls the size of the marginal emission pulse.
 """
-function compute_scc_mm(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015)
+function compute_scc_mm(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
     year === nothing ? error("Must specify an emission year. Try `compute_scc_mm(m, year=2020)`.") : nothing
     !(last_year in 1950:3000) ? error("Invlaid value of $last_year for last_year. last_year must be within the model's time index 1950:3000.") : nothing
     !(year in 1950:last_year) ? error("Cannot compute the scc for year $year, year must be within the model's time index 1950:$last_year.") : nothing
 
-    mm = get_marginal_model(m; year = year, gas = gas)
+    mm = get_marginal_model(m; year = year, gas = gas, pulse_size = pulse_size)
     scc = _compute_scc(mm; year=year, gas=gas, last_year=last_year, equity_weights=equity_weights, eta=eta, prtp=prtp)
     
     return (scc = scc, mm = mm)
@@ -56,7 +58,7 @@ function _compute_scc(mm::MarginalModel; year::Int, gas::Symbol, last_year::Int,
             for t = getindexfromyear(year):ntimesteps
                 df[t, r] = x
                 gr = (ypc[t, r] - ypc[t - 1, r]) / ypc[t - 1,r]
-                x = x / (1. + prtp + eta * gr)
+                x = x / (1. + prtp + eta * gr) 
             end
         end
     else
@@ -70,32 +72,34 @@ function _compute_scc(mm::MarginalModel; year::Int, gas::Symbol, last_year::Int,
 end
 
 """
-get_marginal_model(m::Model = get_model(); year::Int = nothing, gas::Symbol = :CO2)
+get_marginal_model(m::Model = get_model(); year::Int = nothing, gas::Symbol = :CO2, pulse_size::Float64 = 1e7)
 
 Creates a Mimi MarginalModel where the provided m is the base model, and the marginal model has additional emissions of gas `gas` in year `year`.
 If no Model m is provided, the default model from MimiFUND.get_model() is used as the base model.
+`pulse_size` controls the size of the marginal emission pulse.
 """
-function get_marginal_model(m::Model = get_model(); year::Int = nothing, gas::Symbol = :CO2)
-    year == nothing ? error("Must specify emission year. Try `get_marginal_model(m, year=2020)`.") : nothing 
+function get_marginal_model(m::Model = get_model(); year::Int = nothing, gas::Symbol = :CO2, pulse_size::Float64 = 1e7)
+    year === nothing ? error("Must specify emission year. Try `get_marginal_model(m, year=2020)`.") : nothing 
     !(year in 1950:3000) ? error("Cannot add marginal emissions in $year, year must be within the model's time index 1950:3000.") : nothing
 
-    mm = create_marginal_model(m, 1e7)  # pulse size is 1MtC for ten years
-    add_marginal_emissions!(mm.marginal, year; gas = gas)
+    mm = create_marginal_model(m, pulse_size)
+    add_marginal_emissions!(mm.marginal, year; gas = gas, pulse_size = pulse_size)
 
     return mm
 end
 
 """
-Adds a marginalemission component to m, and sets the additional emissions if a year is specified.
+Adds a marginalemission component to `m`, and sets the additional emissions if a year is specified.
+`pulse_size` controls the size of the marginal emission pulse.
 """
-function add_marginal_emissions!(m, year = nothing; gas = :CO2)
+function add_marginal_emissions!(m, year = nothing; gas = :CO2, pulse_size::Float64 = 1e7)
 
     # Add additional emissions to m
     add_comp!(m, Mimi.adder, :marginalemission, before = :climateco2cycle, first = 1951)
     nyears = length(Mimi.time_labels(m))
     addem = zeros(nyears - 1)   # starts one year later, in 1951
     if year != nothing 
-        addem[getindexfromyear(year)-1:getindexfromyear(year) + 8] .= 1.0
+        addem[getindexfromyear(year)-1:getindexfromyear(year) + 8] .= pulse_size / 1e7   # pulse is spread over ten years, and emissions components is in MtCO2, so divide by 1e7
     end
     set_param!(m, :marginalemission, :add, addem)
 
@@ -121,14 +125,14 @@ end
 """
 Helper function to set the marginal emissions in the specified year.
 """
-function perturb_marginal_emissions!(m::Model, year; comp_name = :marginalemission)
+function perturb_marginal_emissions!(m::Model, year; comp_name = :marginalemission, pulse_size::Float64 = 1e7)
 
     ci = compinstance(m, comp_name)
     emissions = Mimi.get_param_value(ci, :add)
 
     nyears = length(Mimi.dimension(m, :time))
     new_em = zeros(nyears - 1)
-    new_em[getindexfromyear(year)-1:getindexfromyear(year) + 8] .= 1.0
+    new_em[getindexfromyear(year)-1:getindexfromyear(year) + 8] .= pulse_size / 1e7
     emissions[:] = new_em
 
 end

--- a/src/new_marginaldamages.jl
+++ b/src/new_marginaldamages.jl
@@ -1,112 +1,211 @@
 import Mimi.compinstance
 
 """
-compute_scc(m::Model=get_model(); year::Int = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+    compute_scc(m::Model=get_model(); year::Int = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015)
 
-Debrecated function for calculating the social cost of carbon for a MimiFUND model. Use `compute_scco2`, `compute_scch4`, `compute_scn2o`, or `compute_scsf6` instead.
+Deprecated function for calculating the social cost of carbon for a MimiFUND model. Use `compute_sc` or gas-specific functions `compute_scco2`, `compute_scch4`, `compute_scn2o`, or `compute_scsf6` instead.
 """
-function compute_scc(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
-    @warn("Deprecation warning: `compute_scc` is deprecated. Use `compute_scco2` or other gas-specific functions instead.")
+function compute_scc(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015)
+    Base.depwarn("`compute_scc` is deprecated. Use `compute_sc` or other gas-specific functions instead.", :MimiFUND)
     year === nothing ? error("Must specify an emission year. Try `compute_scc(year=2020)`.") : nothing
-    return compute_social_cost(m, year = year, gas = gas, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
+    return compute_sc(m, year = year, gas = gas, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
 end
 
 """
-compute_scco2(m::Model=get_model(); year::Int = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+    compute_scco2(m::Model=get_model(); 
+        year::Union{Int, Nothing} = nothing, 
+        eta::Float64 = 1.45, 
+        prtp::Float64 = 0.015, 
+        equity_weights::Bool = false, 
+        last_year::Int = 3000, 
+        pulse_size::Float64 = 1e7, 
+        return_mm::Bool = false,
+        n::Union{Int, Nothing} = nothing,
+        trials_output_filename::Union{String, Nothing} = nothing,
+        seed::Union{Int, Nothing} = nothing)
 
-Computes the social cost of CO2 for the specified `year` for the provided MimiFUND model `m`. 
+Returns the Social Cost of CO2 for the specified `year` for the provided MimiFUND model `m`. 
 If no model is provided, the default model from MimiFUND.get_model() is used.
-The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`, with defaults of 1.45 and 0.015.
-Units of the returned value are [\$ per tonne CO2] in 1995USD.
-Optional regional equity weighting can be used by specifying `equity_weights = true`. 
-The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric tonnes of CO2.
+Units of the returned value are 1995\$ per metric tonne of CO2.
+
+This is a wrapper function that calls the generic social cost function `compute_sc(m, gas = :CO2, args...)`. See docstring for
+`compute_sc` for a full description of the available keyword arguments.
 """
-function compute_scco2(m::Model=get_model(); year::Union{Int, Nothing} = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+function compute_scco2(m::Model=get_model(); year::Union{Int, Nothing} = nothing, eta::Float64 = 1.45, prtp::Float64 = 0.015, equity_weights::Bool = false, last_year::Int = 3000, pulse_size::Float64 = 1e7, 
+    return_mm::Bool = false, n::Union{Int, Nothing} = nothing, trials_output_filename::Union{String, Nothing} = nothing, seed::Union{Int, Nothing} = nothing)
+
     year === nothing ? error("Must specify an emission year. Try `compute_scco2(year=2020)`.") : nothing
-    return compute_social_cost(m, year = year, gas = :CO2, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
+    return compute_sc(m, gas = :CO2, year = year, eta = eta, prtp = prtp, equity_weights = equity_weights, last_year = last_year, pulse_size = pulse_size, 
+                        return_mm = return_mm, n = n, trials_output_filename = trials_output_filename, seed = seed)
 end
 
 """
-compute_scch4(m::Model=get_model(); year::Int = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+    compute_scch4(m::Model=get_model(); 
+        year::Union{Int, Nothing} = nothing, 
+        eta::Float64 = 1.45, 
+        prtp::Float64 = 0.015, 
+        equity_weights::Bool = false, 
+        last_year::Int = 3000, 
+        pulse_size::Float64 = 1e7, 
+        return_mm::Bool = false,
+        n::Union{Int, Nothing} = nothing,
+        trials_output_filename::Union{String, Nothing} = nothing,
+        seed::Union{Int, Nothing} = nothing)
 
-Computes the social cost of CH4 for the specified `year` for the provided MimiFUND model `m`. 
+Returns the Social Cost of CH4 for the specified `year` for the provided MimiFUND model `m`. 
 If no model is provided, the default model from MimiFUND.get_model() is used.
-The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`, with defaults of 1.45 and 0.015.
-Units of the returned value are [\$ per tonne CH4] in 1995USD.
-Optional regional equity weighting can be used by specifying `equity_weights = true`. 
-The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric tonnes of CH4.
+Units of the returned value are 1995\$ per metric tonne of CH4.
+
+This is a wrapper function that calls the generic social cost function `compute_sc(m, gas = :CH4, args...)`. See docstring for
+`compute_sc` for a full description of the available keyword arguments.
 """
-function compute_scch4(m::Model=get_model(); year::Union{Int, Nothing} = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
-    year === nothing ? error("Must specify an emission year with keyword argument `year`. Try `compute_scch4(year=2020)`.") : nothing
-    return compute_social_cost(m, year = year, gas = :CH4, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
+function compute_scch4(m::Model=get_model(); year::Union{Int, Nothing} = nothing, eta::Float64 = 1.45, prtp::Float64 = 0.015, equity_weights::Bool = false, last_year::Int = 3000, pulse_size::Float64 = 1e7, 
+    return_mm::Bool = false, n::Union{Int, Nothing} = nothing, trials_output_filename::Union{String, Nothing} = nothing, seed::Union{Int, Nothing} = nothing)
+
+    year === nothing ? error("Must specify an emission year. Try `compute_scch4(year=2020)`.") : nothing
+    return compute_sc(m, gas = :CH4, year = year, eta = eta, prtp = prtp, equity_weights = equity_weights, last_year = last_year, pulse_size = pulse_size, 
+                        return_mm = return_mm, n = n, trials_output_filename = trials_output_filename, seed = seed)
 end
 
 """
-compute_scn2o(m::Model=get_model(); year::Int = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+    compute_scn2o(m::Model=get_model(); 
+        year::Union{Int, Nothing} = nothing, 
+        eta::Float64 = 1.45, 
+        prtp::Float64 = 0.015, 
+        equity_weights::Bool = false, 
+        last_year::Int = 3000, 
+        pulse_size::Float64 = 1e7, 
+        return_mm::Bool = false,
+        n::Union{Int, Nothing} = nothing,
+        trials_output_filename::Union{String, Nothing} = nothing,
+        seed::Union{Int, Nothing} = nothing)
 
-Computes the social cost of N2O for the specified `year` for the provided MimiFUND model `m`. 
+Returns the Social Cost of N2O for the specified `year` for the provided MimiFUND model `m`. 
 If no model is provided, the default model from MimiFUND.get_model() is used.
-The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`, with defaults of 1.45 and 0.015.
-Units of the returned value are [\$ per tonne N2O] in 1995USD.
-Optional regional equity weighting can be used by specifying `equity_weights = true`. 
-The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric tonnes of N2O.
+Units of the returned value are 1995\$ per metric tonne of N2O.
+
+This is a wrapper function that calls the generic social cost function `compute_sc(m, gas = :N2O, args...)`. See docstring for
+`compute_sc` for a full description of the available keyword arguments.
 """
-function compute_scn2o(m::Model=get_model(); year::Union{Int, Nothing} = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
-    year === nothing ? error("Must specify an emission year with keyword argument `year`. Try `compute_scn2o(year=2020)`.") : nothing
-    return compute_social_cost(m, year = year, gas = :N2O, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
+function compute_scn2o(m::Model=get_model(); year::Union{Int, Nothing} = nothing, eta::Float64 = 1.45, prtp::Float64 = 0.015, equity_weights::Bool = false, last_year::Int = 3000, pulse_size::Float64 = 1e7, 
+    return_mm::Bool = false, n::Union{Int, Nothing} = nothing, trials_output_filename::Union{String, Nothing} = nothing, seed::Union{Int, Nothing} = nothing)
+
+    year === nothing ? error("Must specify an emission year. Try `compute_scn2o(year=2020)`.") : nothing
+    return compute_sc(m, gas = :N2O, year = year, eta = eta, prtp = prtp, equity_weights = equity_weights, last_year = last_year, pulse_size = pulse_size, 
+                        return_mm = return_mm, n = n, trials_output_filename = trials_output_filename, seed = seed)
 end
 
 """
-compute_scsf6(m::Model=get_model(); year::Int = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
+    compute_scsf6(m::Model=get_model(); 
+        year::Union{Int, Nothing} = nothing, 
+        eta::Float64 = 1.45, 
+        prtp::Float64 = 0.015, 
+        equity_weights::Bool = false, 
+        last_year::Int = 3000, 
+        pulse_size::Float64 = 1e7, 
+        return_mm::Bool = false,
+        n::Union{Int, Nothing} = nothing,
+        trials_output_filename::Union{String, Nothing} = nothing,
+        seed::Union{Int, Nothing} = nothing)
 
-Computes the social cost of SF6 for the specified `year` for the provided MimiFUND model `m`. 
+Returns the Social Cost of SF6 for the specified `year` for the provided MimiFUND model `m`. 
 If no model is provided, the default model from MimiFUND.get_model() is used.
-The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`, with defaults of 1.45 and 0.015.
-Units of the returned value are [\$ per tonne SF6] in 1995USD.
-Optional regional equity weighting can be used by specifying `equity_weights = true`. 
-The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric tonnes of SF6.
+Units of the returned value are 1995\$ per metric tonne of SF6.
+
+This is a wrapper function that calls the generic social cost function `compute_sc(m, gas = :SF6, args...)`. See docstring for
+`compute_sc` for a full description of the available keyword arguments.
 """
-function compute_scsf6(m::Model=get_model(); year::Union{Int, Nothing} = nothing, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
-    year === nothing ? error("Must specify an emission year with keyword argument `year`. Try `compute_scn2o(year=2020)`.") : nothing
-    return compute_social_cost(m, year = year, gas = :SF6, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
+function compute_scsf6(m::Model=get_model(); year::Union{Int, Nothing} = nothing, eta::Float64 = 1.45, prtp::Float64 = 0.015, equity_weights::Bool = false, last_year::Int = 3000, pulse_size::Float64 = 1e7, 
+    return_mm::Bool = false, n::Union{Int, Nothing} = nothing, trials_output_filename::Union{String, Nothing} = nothing, seed::Union{Int, Nothing} = nothing)
+
+    year === nothing ? error("Must specify an emission year. Try `compute_scsf6(year=2020)`.") : nothing
+    return compute_sc(m, gas = :SF6, year = year, eta = eta, prtp = prtp, equity_weights = equity_weights, last_year = last_year, pulse_size = pulse_size, 
+                        return_mm = return_mm, n = n, trials_output_filename = trials_output_filename, seed = seed)
 end
 
-# helper function called by each gas-specific function for computing the social cost
-function compute_social_cost(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
-    year === nothing ? error("Must specify an emission year. Try `compute_social_cost(year=2020)`.") : nothing
+"""
+    compute_sc(m::Model=get_model(); 
+        gas::Symbol = :CO2, 
+        year::Union{Int, Nothing} = nothing, 
+        eta::Float64 = 1.45, 
+        prtp::Float64 = 0.015, 
+        equity_weights::Bool = false, 
+        last_year::Int = 3000, 
+        pulse_size::Float64 = 1e7, 
+        return_mm::Bool = false,
+        n::Union{Int, Nothing} = nothing,
+        trials_output_filename::Union{String, Nothing} = nothing,
+        seed::Union{Int, Nothing} = nothing)
+
+Returns the Social Cost of CO2 (or other gas if specified) for the specified `year`
+for the provided MimiFUND model `m`. If no model is provided, the default model from MimiFUND.get_model() is used.
+Units of the returned value are 1995\$ per metric tonne of the specified gas.
+
+The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`.
+Optional regional equity weighting can be used by specifying `equity_weights = true`.
+By default, the social cost includes damages through the year 3000, but this time horizon can be modified 
+by setting the keyword `last_year` to some other year within the model's time index.
+The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric 
+tonnes of the specified gas (this does not change the units of the returned value, which is always normalized
+by the `pulse_size` used).
+
+If `return_mm == true`, then a NamedTuple (sc=sc, mm=mm) of the social cost value and the MarginalModel 
+used to compute it is returned.
+
+By default, `n === nothing`, and a single value for the "best guess" social cost is returned. If a positive 
+value for keyword `n` is specified, then a Monte Carlo simulation with sample size `n` will run, sampling from 
+all of FUND's random variables, and a vector of `n` social cost values will be returned.
+Optionally providing a CSV file path to `trials_output_filename` will save all of the sampled trial data as a CSV file.
+Optionally providing a `seed` value will set the random seed before running the simulation, allowing the 
+results to be replicated.
+"""
+function compute_sc(m::Model=get_model(); 
+    gas::Symbol = :CO2, 
+    year::Union{Int, Nothing} = nothing, 
+    eta::Float64 = 1.45, 
+    prtp::Float64 = 0.015, 
+    equity_weights::Bool = false, 
+    last_year::Int = 3000, 
+    pulse_size::Float64 = 1e7, 
+    return_mm::Bool = false,
+    n::Union{Int, Nothing} = nothing,
+    trials_output_filename::Union{String, Nothing} = nothing,
+    seed::Union{Int, Nothing} = nothing
+    )
+
+    year === nothing ? error("Must specify an emission year. Try `compute_sc(year=2020)`.") : nothing
     !(last_year in 1950:3000) ? error("Invlaid value for `last_year`: $last_year. `last_year` must be within the model's time index 1950:3000.") : nothing
     !(year in 1950:last_year) ? error("Invalid value for `year`: $year. `year` must be within the model's time index 1950:$last_year.") : nothing
 
     mm = get_marginal_model(m; year = year, gas = gas, pulse_size = pulse_size)
 
-    return _compute_sc(mm, year = year, gas = gas, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
-end
-
-"""
-compute_sc_mm(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
-
-Returns a NamedTuple (scc=scc, mm=mm) of the social cost of carbon and the MarginalModel used to compute it.
-Computes the social cost of CO2 (or other gas if specified) for an emissions pulse in `year`
-for the provided MimiFUND model. If no model is provided, the default model from MimiFUND.get_model() is used.
-The discount factor is computed from the specified `eta` and pure rate of time preference `prtp`.
-Optional regional equity weighting can be used by specifying `equity_weights=true`. 
-The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric tonnes.
-"""
-function compute_sc_mm(m::Model=get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, last_year::Int = 3000, equity_weights::Bool = false, eta::Float64 = 1.45, prtp::Float64 = 0.015, pulse_size::Float64 = 1e7)
-    year === nothing ? error("Must specify an emission year. Try `compute_scc_mm(m, year=2020)`.") : nothing
-    !(last_year in 1950:3000) ? error("Invlaid value of $last_year for last_year. last_year must be within the model's time index 1950:3000.") : nothing
-    !(year in 1950:last_year) ? error("Cannot compute the scc for year $year, year must be within the model's time index 1950:$last_year.") : nothing
-
-    mm = get_marginal_model(m; year = year, gas = gas, pulse_size = pulse_size)
-    scc = _compute_sc(mm; year=year, gas=gas, last_year=last_year, equity_weights=equity_weights, eta=eta, prtp=prtp)
-    
-    return (scc = scc, mm = mm)
-end
-
-# helper function for computing SCC from a MarginalModel, not to be exported
-function _compute_sc(mm::MarginalModel; year::Int, gas::Symbol, last_year::Int, equity_weights::Bool, eta::Float64, prtp::Float64)
     ntimesteps = getindexfromyear(last_year)
-    run(mm; ntimesteps = ntimesteps)
+
+    if n === nothing
+        # Run the "best guess" social cost calculation
+        run(mm; ntimesteps = ntimesteps)
+        sc = _compute_sc_from_mm(mm, year = year, gas = gas, ntimesteps = ntimesteps, equity_weights = equity_weights, eta = eta, prtp = prtp)
+    elseif n < 1
+        error("Invalid n = $n. Number of trials must be a positive integer.")
+    else
+        # Run a Monte Carlo simulation
+        simdef = getmcs()
+        payload = (Array{Float64, 1}(undef, n), year, gas, ntimesteps, equity_weights, eta, prtp) # first item is an array to hold SC values calculated in each trial
+        Mimi.set_payload!(simdef, payload) 
+        seed !== nothing ? Random.seed!(seed) : nothing
+        si = run(simdef, mm, n, ntimesteps = ntimesteps, post_trial_func = _fund_sc_post_trial, trials_output_filename = trials_output_filename)
+        sc = Mimi.payload(si)[1]
+    end
+
+    if return_mm
+        return (sc = sc, mm = mm)
+    else
+        return sc
+    end
+end
+
+# helper function for computing SC from a MarginalModel that's already been run, not to be exported
+function _compute_sc_from_mm(mm::MarginalModel; year::Int, gas::Symbol, ntimesteps::Int, equity_weights::Bool, eta::Float64, prtp::Float64)
 
     # Calculate the marginal damage between run 1 and 2 for each year/region
     marginaldamage = mm[:impactaggregation, :loss]
@@ -129,13 +228,21 @@ function _compute_sc(mm::MarginalModel; year::Int, gas::Symbol, last_year::Int, 
         df = Float64[t >= getindexfromyear(year) ? (globalypc[getindexfromyear(year)] / ypc[t, r]) ^ eta / (1.0 + prtp) ^ (t - getindexfromyear(year)) : 0.0 for t = 1:ntimesteps, r = 1:16]
     end 
 
-    # Compute global SCC
-    scc = sum(marginaldamage[2:ntimesteps, :] .* df[2:ntimesteps, :])
-    return scc
+    # Compute global social cost
+    sc = sum(marginaldamage[2:ntimesteps, :] .* df[2:ntimesteps, :])   # need to start from second value because first value is missing
+    return sc
+end
+
+# Post trial function used for computing monte carlo vector of social cost values
+function _fund_sc_post_trial(sim::SimulationInstance, trialnum::Int, ntimesteps::Int, tup::Union{Tuple, Nothing})
+    mm = sim.models[1]  # get the already-run MarginalModel
+    (sc_results, year, gas, ntimesteps, equity_weights, eta, prtp) = Mimi.payload(sim)  # unpack the payload information
+    sc = _compute_sc_from_mm(mm, year = year, gas = gas, ntimesteps = ntimesteps, equity_weights = equity_weights, eta = eta, prtp = prtp)
+    sc_results[trialnum] = sc
 end
 
 """
-get_marginal_model(m::Model = get_model(); year::Int = nothing, gas::Symbol = :CO2, pulse_size::Float64 = 1e7)
+    get_marginal_model(m::Model = get_model(); year::Int = nothing, gas::Symbol = :CO2, pulse_size::Float64 = 1e7)
 
 Creates a Mimi MarginalModel where the provided m is the base model, and the marginal model has additional emissions of gas `gas` in year `year`.
 If no year is provided, the marginal emissions component will be added without an additional pulse.
@@ -205,7 +312,7 @@ end
 """
 Returns a matrix of marginal damages per one metric tonne of additional emissions of the specified gas in the specified year.
 """
-function getmarginaldamages(; year=2010, parameters = nothing, gas = :CO2, pulse_size::Float64 = 1e7) 
+function getmarginaldamages(; year=2020, parameters = nothing, gas = :CO2, pulse_size::Float64 = 1e7) 
 
     # Get marginal model
     m = get_model(params = parameters)

--- a/src/new_marginaldamages.jl
+++ b/src/new_marginaldamages.jl
@@ -149,10 +149,10 @@ The size of the marginal emission pulse can be modified with the `pulse_size` ke
 tonnes of the specified gas (this does not change the units of the returned value, which is always normalized
 by the `pulse_size` used).
 
-If `return_mm == true`, then a NamedTuple (sc=sc, mm=mm) of the social cost value and the MarginalModel 
+If `return_mm` is set to `true`, then a NamedTuple (sc = sc, mm = mm) of the social cost value and the MarginalModel 
 used to compute it is returned.
 
-By default, `n === nothing`, and a single value for the "best guess" social cost is returned. If a positive 
+By default, `n = nothing`, and a single value for the "best guess" social cost is returned. If a positive 
 value for keyword `n` is specified, then a Monte Carlo simulation with sample size `n` will run, sampling from 
 all of FUND's random variables, and a vector of `n` social cost values will be returned.
 Optionally providing a CSV file path to `trials_output_filename` will save all of the sampled trial data as a CSV file.
@@ -220,7 +220,7 @@ function _compute_sc_from_mm(mm::MarginalModel; year::Int, gas::Symbol, ntimeste
             for t = getindexfromyear(year):ntimesteps
                 df[t, r] = x
                 gr = (ypc[t, r] - ypc[t - 1, r]) / ypc[t - 1,r]
-                x = x / (1. + prtp + eta * gr) 
+                x = x / (1. + prtp + eta * gr)
             end
         end
     else
@@ -242,14 +242,14 @@ function _fund_sc_post_trial(sim::SimulationInstance, trialnum::Int, ntimesteps:
 end
 
 """
-    get_marginal_model(m::Model = get_model(); year::Int = nothing, gas::Symbol = :CO2, pulse_size::Float64 = 1e7)
+    get_marginal_model(m::Model = get_model(); gas::Symbol = :CO2, year::Int = nothing, pulse_size::Float64 = 1e7)
 
 Creates a Mimi MarginalModel where the provided m is the base model, and the marginal model has additional emissions of gas `gas` in year `year`.
 If no year is provided, the marginal emissions component will be added without an additional pulse.
 If no Model m is provided, the default model from MimiFUND.get_model() is used as the base model.
 The size of the marginal emission pulse can be modified with the `pulse_size` keyword argument, in metric tonnes.
 """
-function get_marginal_model(m::Model = get_model(); year::Union{Int, Nothing} = nothing, gas::Symbol = :CO2, pulse_size::Float64 = 1e7)
+function get_marginal_model(m::Model = get_model(); gas::Symbol = :CO2, year::Union{Int, Nothing} = nothing, pulse_size::Float64 = 1e7)
     year !== nothing && !(year in 1950:3000) ? error("Cannot add marginal emissions in $year, year must be within the model's time index 1950:3000.") : nothing
 
     mm = create_marginal_model(m, pulse_size)

--- a/src/new_marginaldamages.jl
+++ b/src/new_marginaldamages.jl
@@ -79,7 +79,7 @@ function compute_social_cost(m::Model=get_model(); year::Union{Int, Nothing} = n
 
     mm = get_marginal_model(m; year = year, gas = gas, pulse_size = pulse_size)
 
-    return _compute_scc(mm, year = year, gas = gas, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
+    return _compute_sc(mm, year = year, gas = gas, last_year = last_year, equity_weights = equity_weights, eta = eta, prtp = prtp)
 end
 
 """
@@ -98,13 +98,13 @@ function compute_sc_mm(m::Model=get_model(); year::Union{Int, Nothing} = nothing
     !(year in 1950:last_year) ? error("Cannot compute the scc for year $year, year must be within the model's time index 1950:$last_year.") : nothing
 
     mm = get_marginal_model(m; year = year, gas = gas, pulse_size = pulse_size)
-    scc = _compute_scc(mm; year=year, gas=gas, last_year=last_year, equity_weights=equity_weights, eta=eta, prtp=prtp)
+    scc = _compute_sc(mm; year=year, gas=gas, last_year=last_year, equity_weights=equity_weights, eta=eta, prtp=prtp)
     
     return (scc = scc, mm = mm)
 end
 
 # helper function for computing SCC from a MarginalModel, not to be exported
-function _compute_scc(mm::MarginalModel; year::Int, gas::Symbol, last_year::Int, equity_weights::Bool, eta::Float64, prtp::Float64)
+function _compute_sc(mm::MarginalModel; year::Int, gas::Symbol, last_year::Int, equity_weights::Bool, eta::Float64, prtp::Float64)
     ntimesteps = getindexfromyear(last_year)
     run(mm; ntimesteps = ntimesteps)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,35 +82,40 @@ end #fund-integration testset
 
 # Test functions from file "new_marginaldamages.jl"
 
-# Test the compute_scc function with various keyword arguments
-scc1 = MimiFUND.compute_scc(year = 2020) 
+# Test the compute_scco2 function with various keyword arguments
+scc1 = MimiFUND.compute_scco2(year = 2020) 
 @test scc1 isa Float64   # test that it's not missing or a NaN
-scc2 = MimiFUND.compute_scc(year = 2020, last_year=2300) 
+scc2 = MimiFUND.compute_scco2(year = 2020, last_year=2300) 
 @test scc2 < scc1  # test that shorter horizon made it smaller
-scc3 = MimiFUND.compute_scc(year = 2020, last_year=2300, equity_weights=true) 
+scc3 = MimiFUND.compute_scco2(year = 2020, last_year=2300, equity_weights=true) 
 @test scc3 > scc2  # test that equity weights made itbigger
-scc4 = MimiFUND.compute_scc(year = 2020, last_year=2300, equity_weights=true, eta=.8, prtp=0.01) 
+scc4 = MimiFUND.compute_scco2(year = 2020, last_year=2300, equity_weights=true, eta=.8, prtp=0.01) 
 @test scc4 > scc3   # test that lower eta and prtp make scc higher
-scc5 = MimiFUND.compute_scc(year = 2020, gas=:CH4) 
-@test scc5 > scc1   # test social cost of methane is higher
+scch4 = MimiFUND.compute_scch4(year = 2020) 
+@test scch4 > scc1   # test social cost of methane is higher
 
 # Test with a modified model
 m = MimiFUND.get_model()
 update_param!(m, :climatesensitivity, 5)    
-scc6 = MimiFUND.compute_scc(m, year=2020, last_year=2300)
+scc6 = MimiFUND.compute_scco2(m, year=2020, last_year=2300)
 @test scc6 > scc2 # test that it's higher than the default because of a higher climate sensitivity 
 
 # Test get_marginal_model
 mm = MimiFUND.get_marginal_model(year=2020, gas=:CH4)
 run(mm)
 
-# Test compute_scc_mm
-result = MimiFUND.compute_scc_mm(year=2050)
+# Test compute_sc_mm
+result = MimiFUND.compute_sc_mm(year=2050)
 @test result.scc isa Float64
 @test result.mm isa Mimi.MarginalModel
 
-# Test old exported versions of the functions
-scc = MimiFUND.get_social_cost()
+# Test other gases
+scch4 = MimiFUND.compute_scch4(year = 2020)
+scn2o = MimiFUND.compute_scn2o(year = 2020)
+scsf6 = MimiFUND.compute_scsf6(year = 2020)
+@test scsf6 < scch4 < scn2o
+
+# Test old exported marginal damage function
 md = MimiFUND.getmarginaldamages()
 
 end #marginaldamages testset


### PR DESCRIPTION
This PR:
- renames `compute_scc` to `compute_scco2` for clarity, because the returned units are [$ per metric tonne of CO2] (and adds a deprecation warning for `compute_scc`)
- adds functions for `compute_scch4`, `compute_scn2o`, and `compute_scsf6`
- adds the `pulse_size` option to the `compute_scco2` with default 1e7 metric tonnes of CO2. The provided value is set as the `delta` in the `MarginalModel`, but is multiplied by (1e-7 * 12/44) before being set as the marginal emissions pulse, because the emissions component in FUND expects million tonnes of carbon, and is set for ten years. I would appreciate it if someone double checks the logic of this!

Questions:
- The default pulse size used to be 1e7 tonnes of C, now we are changing it to be interpreted as 1e7 tonnes of CO2. This slightly changes the "default" value of the SCC that gets returned. Do we care about this?
- How do I do an actual deprecation warning, and do we want this? (Currently lines 3-7 in "new_marginaldamages.jl")
- In "docs/tables.md", it says that units for carbon dioxide emissions are in "million metric tonnes of carbon". Is this still true, even though the variable in the emissions component is called `mco2`?
- What are the units of the other gases in the emissions component? They are described as a proportion of levels in 2000 (at least that's what it looks like in the tables.md file). My current descriptions of units in the docstrings and implementation of `pulse_size` for each gas-specific social cost function are assuming that they are in mega tonnes as well. 
- Are the economic units in 1995 USD? (would like to write this correctly in the documentation for SCC)
- I currently added separate `compute_scc...` functions for each available gas. I did not add separate functions for the `compute_scc_mm` function that returns a NamedTuple.  Instead I just renamed it to `compute_sc_mm` and still allow for the `gas` keyword argument. Let me know if I should add separate versions of this function for each gas as well.