### PR TITLE
Fix `nsteps` bug

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,9 +24,13 @@ m1 = MimiFUND.get_model()
 run(m1)
 @test Mimi.time_labels(m1) == collect(1950:1:1950+default_nsteps)
 
-#use optional args for MimiFUND.get_model()
-new_nsteps = 10
-@test_throws ErrorException m2 = MimiFUND.get_model(nsteps = new_nsteps) #should error because parameter lenghts won't match time dim
+# use optional `nsteps` arg for MimiFUND.get_model()
+@test_throws ErrorException m2 = MimiFUND.get_model(nsteps = 2000) # should error because it's longer than the default without providing different parameters
+new_nsteps = 350
+m2 = MimiFUND.get_model(nsteps = new_nsteps)
+@test length(Mimi.dimension(m2, :time)) == new_nsteps + 1
+run(m2)
+@test length(m2[:climatedynamics, :temp]) == new_nsteps + 1
 
 end #fund-model testset
 


### PR DESCRIPTION
This implements the following, which is my interpretation of the two use cases of the `nsteps` option to `get_model`:
1. If a user wants to use the `nsteps` option just to shorten the time dimension, still using all the default FUND parameter values, then we need to wait to reset the time dimension until after calling `set_leftover_params!`, since this currently produces an error from Mimi since the default parameter values are longer than the requested time dimension. 
2. But if a user wants `nsteps` to be longer than the `default_nsteps`, then they need to provide an alternative `datadir` or `params` dictionary with values that will work for that length of time dimension. In this case, we set the new time dimension _before_ setting the parameter values.