### PR TITLE
- Reverted fix that renamed :population component

### DIFF
--- a/src/MimiFUND.jl
+++ b/src/MimiFUND.jl
@@ -88,7 +88,7 @@ function get_model(; nsteps = default_nsteps, datadir = default_datadir, params 
     # ---------------------------------------------
 
     add_comp!(m, scenariouncertainty)
-    add_comp!(m, population, :pop_component)          # can't have external params and components with the same name
+    add_comp!(m, population)          # can't have external params and components with the same name
     add_comp!(m, geography)
     add_comp!(m, socioeconomic)
     add_comp!(m, emissions)
@@ -123,15 +123,15 @@ function get_model(; nsteps = default_nsteps, datadir = default_datadir, params 
 
     connect_param!(m, :geography, :landloss, :impactsealevelrise, :landloss)
 
-    connect_param!(m, :pop_component, :pgrowth, :scenariouncertainty, :pgrowth)
-    connect_param!(m, :pop_component, :enter, :impactsealevelrise, :enter)
-    connect_param!(m, :pop_component, :leave, :impactsealevelrise, :leave)
-    connect_param!(m, :pop_component, :dead, :impactdeathmorbidity, :dead)
+    connect_param!(m, :population, :pgrowth, :scenariouncertainty, :pgrowth)
+    connect_param!(m, :population, :enter, :impactsealevelrise, :enter)
+    connect_param!(m, :population, :leave, :impactsealevelrise, :leave)
+    connect_param!(m, :population, :dead, :impactdeathmorbidity, :dead)
 
     connect_param!(m, :socioeconomic, :area, :geography, :area)
-    connect_param!(m, :socioeconomic, :globalpopulation, :pop_component, :globalpopulation)
-    connect_param!(m, :socioeconomic, :populationin1, :pop_component, :populationin1)
-    connect_param!(m, :socioeconomic, :population, :pop_component, :population)
+    connect_param!(m, :socioeconomic, :globalpopulation, :population, :globalpopulation)
+    connect_param!(m, :socioeconomic, :populationin1, :population, :populationin1)
+    connect_param!(m, :socioeconomic, :population, :population, :population)
     connect_param!(m, :socioeconomic, :pgrowth, :scenariouncertainty, :pgrowth)
     connect_param!(m, :socioeconomic, :ypcgrowth, :scenariouncertainty, :ypcgrowth)
     connect_param!(m, :socioeconomic, :eloss, :impactaggregation, :eloss)
@@ -139,7 +139,7 @@ function get_model(; nsteps = default_nsteps, datadir = default_datadir, params 
     connect_param!(m, :socioeconomic, :mitigationcost, :emissions, :mitigationcost)
 
     connect_param!(m, :emissions, :income, :socioeconomic, :income)
-    connect_param!(m, :emissions, :population, :pop_component, :population)
+    connect_param!(m, :emissions, :population, :population, :population)
     connect_param!(m, :emissions, :forestemm, :scenariouncertainty, :forestemm)
     connect_param!(m, :emissions, :aeei, :scenariouncertainty, :aeei)
     connect_param!(m, :emissions, :acei, :scenariouncertainty, :acei)
@@ -168,7 +168,7 @@ function get_model(; nsteps = default_nsteps, datadir = default_datadir, params 
 
     connect_param!(m, :ocean, :temp, :climatedynamics, :temp)
 
-    connect_param!(m, :impactagriculture, :population, :pop_component, :population)
+    connect_param!(m, :impactagriculture, :population, :population, :population)
     connect_param!(m, :impactagriculture, :income, :socioeconomic, :income)
     connect_param!(m, :impactagriculture, :temp, :climateregional, :temp)
     connect_param!(m, :impactagriculture, :acco2, :climateco2cycle, :acco2)
@@ -176,50 +176,50 @@ function get_model(; nsteps = default_nsteps, datadir = default_datadir, params 
     connect_param!(m, :impactbiodiversity, :temp, :climateregional, :temp)
     connect_param!(m, :impactbiodiversity, :nospecies, :biodiversity, :nospecies)
     connect_param!(m, :impactbiodiversity, :income, :socioeconomic, :income)
-    connect_param!(m, :impactbiodiversity, :population, :pop_component, :population)
+    connect_param!(m, :impactbiodiversity, :population, :population, :population)
 
-    connect_param!(m, :impactcardiovascularrespiratory, :population, :pop_component, :population)
+    connect_param!(m, :impactcardiovascularrespiratory, :population, :population, :population)
     connect_param!(m, :impactcardiovascularrespiratory, :temp, :climateregional, :temp)
     connect_param!(m, :impactcardiovascularrespiratory, :plus, :socioeconomic, :plus)
     connect_param!(m, :impactcardiovascularrespiratory, :urbpop, :socioeconomic, :urbpop)
 
-    connect_param!(m, :impactcooling, :population, :pop_component, :population)
+    connect_param!(m, :impactcooling, :population, :population, :population)
     connect_param!(m, :impactcooling, :income, :socioeconomic, :income)
     connect_param!(m, :impactcooling, :temp, :climateregional, :temp)
     connect_param!(m, :impactcooling, :cumaeei, :emissions, :cumaeei)
 
-    connect_param!(m, :impactdiarrhoea, :population, :pop_component, :population)
+    connect_param!(m, :impactdiarrhoea, :population, :population, :population)
     connect_param!(m, :impactdiarrhoea, :income, :socioeconomic, :income)
     connect_param!(m, :impactdiarrhoea, :regtmp, :climateregional, :regtmp)
 
-    connect_param!(m, :impactextratropicalstorms, :population, :pop_component, :population)
+    connect_param!(m, :impactextratropicalstorms, :population, :population, :population)
     connect_param!(m, :impactextratropicalstorms, :income, :socioeconomic, :income)
     connect_param!(m, :impactextratropicalstorms, :acco2, :climateco2cycle, :acco2)
 
-    connect_param!(m, :impactforests, :population, :pop_component, :population)
+    connect_param!(m, :impactforests, :population, :population, :population)
     connect_param!(m, :impactforests, :income, :socioeconomic, :income)
     connect_param!(m, :impactforests, :temp, :climateregional, :temp)
     connect_param!(m, :impactforests, :acco2, :climateco2cycle, :acco2)
 
-    connect_param!(m, :impactheating, :population, :pop_component, :population)
+    connect_param!(m, :impactheating, :population, :population, :population)
     connect_param!(m, :impactheating, :income, :socioeconomic, :income)
     connect_param!(m, :impactheating, :temp, :climateregional, :temp)
     connect_param!(m, :impactheating, :cumaeei, :emissions, :cumaeei)
 
-    connect_param!(m, :impactvectorbornediseases, :population, :pop_component, :population)
+    connect_param!(m, :impactvectorbornediseases, :population, :population, :population)
     connect_param!(m, :impactvectorbornediseases, :income, :socioeconomic, :income)
     connect_param!(m, :impactvectorbornediseases, :temp, :climateregional, :temp)
 
-    connect_param!(m, :impacttropicalstorms, :population, :pop_component, :population)
+    connect_param!(m, :impacttropicalstorms, :population, :population, :population)
     connect_param!(m, :impacttropicalstorms, :income, :socioeconomic, :income)
     connect_param!(m, :impacttropicalstorms, :regstmp, :climateregional, :regstmp)
 
-    connect_param!(m, :vslvmorb, :population, :pop_component, :population)
+    connect_param!(m, :vslvmorb, :population, :population, :population)
     connect_param!(m, :vslvmorb, :income, :socioeconomic, :income)
 
     connect_param!(m, :impactdeathmorbidity, :vsl, :vslvmorb, :vsl)
     connect_param!(m, :impactdeathmorbidity, :vmorb, :vslvmorb, :vmorb)
-    connect_param!(m, :impactdeathmorbidity, :population, :pop_component, :population)
+    connect_param!(m, :impactdeathmorbidity, :population, :population, :population)
     connect_param!(m, :impactdeathmorbidity, :dengue, :impactvectorbornediseases, :dengue)
     connect_param!(m, :impactdeathmorbidity, :schisto, :impactvectorbornediseases, :schisto)
     connect_param!(m, :impactdeathmorbidity, :malaria, :impactvectorbornediseases, :malaria)
@@ -231,11 +231,11 @@ function get_model(; nsteps = default_nsteps, datadir = default_datadir, params 
     connect_param!(m, :impactdeathmorbidity, :extratropicalstormsdead, :impactextratropicalstorms, :extratropicalstormsdead)
     connect_param!(m, :impactdeathmorbidity, :diasick, :impactdiarrhoea, :diasick)
 
-    connect_param!(m, :impactwaterresources, :population, :pop_component, :population)
+    connect_param!(m, :impactwaterresources, :population, :population, :population)
     connect_param!(m, :impactwaterresources, :income, :socioeconomic, :income)
     connect_param!(m, :impactwaterresources, :temp, :climateregional, :temp)
 
-    connect_param!(m, :impactsealevelrise, :population, :pop_component, :population)
+    connect_param!(m, :impactsealevelrise, :population, :population, :population)
     connect_param!(m, :impactsealevelrise, :income, :socioeconomic, :income)
     connect_param!(m, :impactsealevelrise, :sea, :ocean, :sea)
     connect_param!(m, :impactsealevelrise, :area, :geography, :area)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,12 +48,12 @@ err_number = 1.0e-9
 err_array = 0.0
 
 # for c in map(name, Mimi.compdefs(m)), v in Mimi.variable_names(m, c)
-for c in Mimi.compdefs(m), v in Mimi.variable_names(m, name(c))
+for c in Mimi.compdefs(m), v in Mimi.variable_names(m, nameof(c))
 
     # load data for comparison
     orig_name = c.comp_id.comp_name
     filename = joinpath(@__DIR__, "../contrib/validation_data_v040/$orig_name-$v.csv")
-    results = m[name(c), v]
+    results = m[nameof(c), v]
 
     df = load(filename) |> DataFrame
     if typeof(results) <: Number
@@ -89,23 +89,23 @@ end #fund-integration testset
 
 # Test the compute_scco2 function with various keyword arguments
 scc0 = MimiFUND.compute_sc(year = 2020, gas = :CO2)
-scc1 = MimiFUND.compute_scco2(year = 2020) 
+scc1 = MimiFUND.compute_scco2(year = 2020)
 @test scc1 isa Float64   # test that it's not missing or a NaN
 @test scc0 == scc1
-scc2 = MimiFUND.compute_scco2(year = 2020, last_year=2300) 
+scc2 = MimiFUND.compute_scco2(year = 2020, last_year=2300)
 @test scc2 < scc1  # test that shorter horizon made it smaller
-scc3 = MimiFUND.compute_scco2(year = 2020, last_year=2300, equity_weights=true) 
+scc3 = MimiFUND.compute_scco2(year = 2020, last_year=2300, equity_weights=true)
 @test scc3 > scc2  # test that equity weights made itbigger
-scc4 = MimiFUND.compute_scco2(year = 2020, last_year=2300, equity_weights=true, eta=.8, prtp=0.01) 
+scc4 = MimiFUND.compute_scco2(year = 2020, last_year=2300, equity_weights=true, eta=.8, prtp=0.01)
 @test scc4 > scc3   # test that lower eta and prtp make scc higher
-scch4 = MimiFUND.compute_scch4(year = 2020) 
+scch4 = MimiFUND.compute_scch4(year = 2020)
 @test scch4 > scc1   # test social cost of methane is higher
 
 # Test with a modified model
 m_high_cs = MimiFUND.get_model()
-update_param!(m_high_cs, :climatesensitivity, 5)    
+update_param!(m_high_cs, :climatesensitivity, 5)
 scc6 = MimiFUND.compute_scco2(m_high_cs, year=2020, last_year=2300)
-@test scc6 > scc2 # test that it's higher than the default because of a higher climate sensitivity 
+@test scc6 > scc2 # test that it's higher than the default because of a higher climate sensitivity
 
 # Test get_marginal_model
 mm = MimiFUND.get_marginal_model(year=2020, gas=:CH4)
@@ -183,9 +183,9 @@ for spec in [
 ]
     # Compute the value for this set of keyword arguments
     sc = MimiFUND.compute_sc(gas = spec.gas, year = spec.year, eta = spec.eta, prtp = spec.prtp, equity_weights = spec.equity_weights, equity_weights_normalization_region = spec.equity_weights_normalization_region, last_year = spec.last_year, pulse_size = spec.pulse_size)
-    
+
     # Get the pre-saved value for this set of keyword arguments
-    validation_value = validation_results |> 
+    validation_value = validation_results |>
         @filter(_.gas == string(spec.gas) && _.year == spec.year && _.eta == spec.eta && _.prtp == spec.prtp && _.equity_weights == string(spec.equity_weights) && _.equity_weights_normalization_region == spec.equity_weights_normalization_region && _.last_year == spec.last_year && _.pulse_size == spec.pulse_size) |>
         DataFrame
 


### PR DESCRIPTION
Fixing param exports obviated this change: the `:population` param is now connected so it doesn't get propagated.

Also removed use of deprecated `name(comp)` in favor of `nameof(comp)`.

Note that this cannot be merged until the `fix-param-exports` branch on Mimi is merged and tagged.